### PR TITLE
Update to NET 7.0, Dalamud 8, Offsets

### DIFF
--- a/HUDManager/HUDManager.csproj
+++ b/HUDManager/HUDManager.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net60-windows</TargetFramework>
-        <Version>2.5.8.1</Version>
+        <TargetFramework>net7.0-windows</TargetFramework>
+        <Version>2.5.9.1</Version>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
@@ -48,14 +48,14 @@
     </ItemGroup>
 	
     <ItemGroup>
-        <PackageReference Include="Costura.Fody" Version="5.1.0" PrivateAssets="all" />
-        <PackageReference Include="DalamudPackager" Version="2.1.7" />
-        <PackageReference Include="Fody" Version="6.5.1">
+        <PackageReference Include="Costura.Fody" Version="5.7.0" PrivateAssets="all" />
+        <PackageReference Include="DalamudPackager" Version="2.1.10" />
+        <PackageReference Include="Fody" Version="6.6.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Resourcer.Fody" Version="1.8.0" PrivateAssets="all" />
-        <PackageReference Include="YamlDotNet" Version="11.0.1" GeneratePathProperty="true" />
+        <PackageReference Include="YamlDotNet" Version="12.3.1" GeneratePathProperty="true" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -177,7 +177,7 @@ namespace HUD_Manager
         public bool IsInFate(Character player)
         {
             unsafe {
-                ////var fateManager = *FateManager.Instance();
+                var fateManager = *FateManager.Instance();
                 ////return (fateManager.FateJoined & 1) == 1;
 
                 return (Marshal.ReadByte(inFateAreaPtr) == 1);

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -177,7 +177,7 @@ namespace HUD_Manager
         public bool IsInFate(Character player)
         {
             unsafe {
-                var fateManager = *FateManager.Instance();
+                ////var fateManager = *FateManager.Instance();
                 ////return (fateManager.FateJoined & 1) == 1;
 
                 return (Marshal.ReadByte(inFateAreaPtr) == 1);

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -40,25 +40,22 @@ namespace HUD_Manager
 
         public static byte GetStatus(GameObject actor)
         {
-            // Updated: 6.2
-            // 40 57 48 83 EC 70 48 8B F9 E8 ?? ?? ?? ?? 81 BF ?? ?? ?? ?? ?? ?? ?? ??
-            const int offset = 0x1AEF;
+            // Updated: 6.3
+            const int offset = 0x1B1B;
             return Marshal.ReadByte(actor.Address + offset);
         }
 
         internal static byte GetOnlineStatus(GameObject actor)
         {
-            // Updated: 6.2
-            // E8 ?? ?? ?? ?? 48 85 C0 75 54
-            const int offset = 0x1AD6;
+            // Updated: 6.3
+            const int offset = 0x1B02;
             return Marshal.ReadByte(actor.Address + offset);
         }
 
         internal static byte GetBardThing(GameObject actor)
         {
-            // Updated: 5.5
-            // E8 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 0F B6 43 50
-            const int offset = 0x197C;
+            // Updated: 6.3
+            const int offset = 0x1B00;
             return Marshal.ReadByte(actor.Address + offset);
         }
 
@@ -399,10 +396,10 @@ namespace HUD_Manager
                     return plugin.Condition[ConditionFlag.OccupiedInEvent]
                         | plugin.Condition[ConditionFlag.OccupiedInQuestEvent]
                         | plugin.Condition[ConditionFlag.OccupiedSummoningBell];
-                case Status.InFate:
-                    return plugin.Statuses.IsInFate(player!);
-                case Status.InFateLevelSynced:
-                    return plugin.Statuses.IsInFate(player!) && plugin.Statuses.IsLevelSynced(player!);
+                ////case Status.InFate:
+                ////    return plugin.Statuses.IsInFate(player!);
+                ////case Status.InFateLevelSynced:
+                ////    return plugin.Statuses.IsInFate(player!) && plugin.Statuses.IsLevelSynced(player!);
                 case Status.InSanctuary:
                     return plugin.Statuses.IsInSanctuary();
                 case Status.ChatFocused:

--- a/HUDManager/Ui/Debug.cs
+++ b/HUDManager/Ui/Debug.cs
@@ -133,7 +133,7 @@ namespace HUD_Manager.Ui
             }
 
             if (ImGui.Button("FATE Status")) {
-                PluginLog.Log($"{this.Plugin.Statuses.IsInFate(this.Plugin.ClientState.LocalPlayer)}");
+                ////PluginLog.Log($"{this.Plugin.Statuses.IsInFate(this.Plugin.ClientState.LocalPlayer)}");
                 PluginLog.Log($"{this.Plugin.Statuses.IsLevelSynced(this.Plugin.ClientState.LocalPlayer)}");
 
             }

--- a/HUDManager/packages.lock.json
+++ b/HUDManager/packages.lock.json
@@ -1,28 +1,28 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0-windows7.0": {
+    "net7.0-windows7.0": {
       "Costura.Fody": {
         "type": "Direct",
-        "requested": "[5.1.0, )",
-        "resolved": "5.1.0",
-        "contentHash": "E2MxSGpyLESpEQzySIuimKLhPyHnueTp0iGdpNAL9152Q7dlFZms5aBH5XMVRBiIDXhKvYlyndUmZf2hwbizNQ==",
+        "requested": "[5.7.0, )",
+        "resolved": "5.7.0",
+        "contentHash": "MmL28WOOnJEBWORXj6bfSxfWaZW8gWSXEJTdrjB9AQi4COX6RXr2xdGL9HsxpWwn6f5Io0NmNuwFJe94w1YmQA==",
         "dependencies": {
-          "Fody": "6.4.0",
+          "Fody": "6.5.5",
           "NETStandard.Library": "1.6.1"
         }
       },
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.7, )",
-        "resolved": "2.1.7",
-        "contentHash": "jnZ/sdInyn07ycuWI+pPOtP/xE3v+c4+jYJfDt36FWnBF9NKqkpzfviJtPl/jGLgbaCmFIXu+Yid0N8GvdKefg=="
+        "requested": "[2.1.10, )",
+        "resolved": "2.1.10",
+        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
       },
       "Fody": {
         "type": "Direct",
-        "requested": "[6.5.1, )",
-        "resolved": "6.5.1",
-        "contentHash": "DEw9rPG5vrpaK4vPPze0f4q6Zd0mfzjGNKy49nrmINkftIHpkyf8KH+uC/qF8y6v1askPWu9NbJS9bkmN5wXaA=="
+        "requested": "[6.6.4, )",
+        "resolved": "6.6.4",
+        "contentHash": "vLZS+oa+ndUHYPlx/8n9bBTT3dHkCF0riml4paKq4D663+cZd47x1uagQo32D/gKFZ/sfmV1oqKaLmH0elxq4A=="
       },
       "Resourcer.Fody": {
         "type": "Direct",
@@ -36,9 +36,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[11.0.1, )",
-        "resolved": "11.0.1",
-        "contentHash": "UvICfSN4gJfAmOsuY/go0hb5SFfr3ZYCXb7jg66yT7kh+wSJEt7tUiwuoCNMpt8ScEXLDwXttpFoWKWeirYU1A=="
+        "requested": "[12.3.1, )",
+        "resolved": "12.3.1",
+        "contentHash": "5AuPSmnxs77+u8oLEW9iF+DUOzkb+VVsJ1IUPYcRJCho0hkLWGO59ZZOr7Mto31oExP8Nm9Q+4BzVwU6sIDQWA=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",


### PR DESCRIPTION
Updated to Net 7.0, Dalamud 8 and the offsets.

Disabled IsInFate because, if you are i a sanctuary, FateManager causes NullRef and if you are not in a sanctuary and you are in a fate FateManager.FateJoined is always 0.

PadMod returns also always 0. 