### PR TITLE
CrossUp integration

### DIFF
--- a/HUDManager/Configuration/SavedLayout.cs
+++ b/HUDManager/Configuration/SavedLayout.cs
@@ -16,6 +16,7 @@ namespace HUD_Manager.Configuration
         // The original approach was to have a superclass "ExternalElement" but this causes some weird issues with deserialization, in
         //  which Dalamud would reset the BrowsingwayOverlay to an ExternalElement, wiping all the data in the process.
         public List<BrowsingwayOverlay> BrowsingwayOverlays { get; } = new List<BrowsingwayOverlay>();
+        public CrossUpConfig? CrossUpConfig { get; set; }
 
         // public Dictionary<string, Vector2<short>> Positions { get; private set; }
 
@@ -32,12 +33,13 @@ namespace HUD_Manager.Configuration
             this.Parent = parent;
         }
 
-        public SavedLayout(string name, Dictionary<ElementKind, Element> elements, Dictionary<string, Window> windows, List<BrowsingwayOverlay> overlays, Guid parent) : this(name, elements, windows, parent)
+        public SavedLayout(string name, Dictionary<ElementKind, Element> elements, Dictionary<string, Window> windows, List<BrowsingwayOverlay> overlays, CrossUpConfig? xup, Guid parent) : this(name, elements, windows, parent)
         {
             this.BrowsingwayOverlays = overlays;
+            this.CrossUpConfig = xup;
         }
-
-        public SavedLayout(string name, Layout hud, Dictionary<string, Window> windows)
+        
+public SavedLayout(string name, Layout hud, Dictionary<string, Window> windows)
         {
             this.Name = name;
             this.Elements = hud.ToDictionary();
@@ -57,6 +59,7 @@ namespace HUD_Manager.Configuration
             this.Elements = layout.Elements;
             this.Windows = layout.Windows;
             this.BrowsingwayOverlays = layout.BrowsingwayOverlays;
+            this.CrossUpConfig = layout.CrossUpConfig;
             this.Parent = layout.Parent;
         }
 

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -204,6 +204,7 @@ namespace HUD_Manager
             var elements = new Dictionary<ElementKind, Element>();
             var windows = new Dictionary<string, Window>();
             var bwOverlays = new List<BrowsingwayOverlay>();
+            CrossUpConfig? crossUpConfig;
 
             // Apply each element of a layout on top of the virtual layout we are constructing.
             void ApplyLayout(Node<SavedLayout> node)
@@ -239,6 +240,9 @@ namespace HUD_Manager
                     }
                     findOverlay.UpdateEnabled(overlay);
                 }
+
+                crossUpConfig = node.Value.CrossUpConfig?.Clone();
+
             }
 
             // get the ancestors and their elements for this node
@@ -261,7 +265,7 @@ namespace HUD_Manager
                 }
             }
 
-            return new SavedLayout($"Effective {id}", elements, windows, bwOverlays, Guid.Empty);
+            return new SavedLayout($"Effective {id}", elements, windows, bwOverlays, crossUpConfig, Guid.Empty);
         }
 
         public void WriteEffectiveLayout(HudSlot slot, Guid id, List<Guid>? layers = null)
@@ -290,6 +294,8 @@ namespace HUD_Manager
             foreach (var overlay in effective.BrowsingwayOverlays) {
                 overlay.ApplyOverlay(Plugin);
             }
+
+            effective.CrossUpConfig?.ApplyConfig(Plugin);
         }
 
         internal void ImportSlot(string name, HudSlot slot, bool save = true)

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -376,6 +376,8 @@ namespace HUD_Manager
         ChatFocused = -9,
         InputModeKbm = -10,
         InputModeGamepad = -11,
+        Windowed = -12,
+        FullScreen = -13,
     }
 
     public static class StatusExtensions
@@ -417,6 +419,10 @@ namespace HUD_Manager
                     return "Keyboard/mouse mode";
                 case Status.InputModeGamepad:
                     return "Gamepad mode";
+                case Status.Windowed:
+                    return "Windowed";
+                case Status.FullScreen:
+                    return "Full Screen";
             }
 
             throw new ApplicationException($"No name was set up for {status}");
@@ -466,6 +472,10 @@ namespace HUD_Manager
                     return !Util.GamepadModeActive();
                 case Status.InputModeGamepad:
                     return Util.GamepadModeActive();
+                case Status.Windowed:
+                    return !Util.FullScreen();
+                case Status.FullScreen:
+                    return Util.FullScreen();
             }
 
             return false;

--- a/HUDManager/Structs/External/CrossUp.cs
+++ b/HUDManager/Structs/External/CrossUp.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Numerics;
+using Dalamud.Logging;
+using HUD_Manager;
+
+namespace HUDManager.Structs.External;
+
+[Serializable]
+public class CrossUpConfig
+{
+    public CrossUpComponent Enabled { get; set; }
+
+    public (bool on, int distance, int center) Split = (false, 100, 0);
+    public (int x, int y, bool hide) Padlock = (0, 0, false);
+    public (int x, int y, bool hide) SetNum = (0, 0, false);
+    public (int x, int y) ChangeSet = (0, 0);
+    public bool HideTriggerText;
+    public bool HideUnassigned;
+    public (int style, int blend, Vector3 color) SelectBG = (0, 0, new(1f / 2.55f));
+    public (Vector3 glow, Vector3 pulse) Buttons = (new(1f), new(1f));
+    public (Vector3 color, Vector3 glow, Vector3 border) Text = (new(1f), new(0.616f, 0.514f, 0.357f), new(1f));
+    public bool SepEx;
+    public bool OnlyOneEx;
+    public (int x, int y) LRpos = (-214, -88);
+    public (int x, int y) RLpos = (214, -88);
+
+    public CrossUpConfig()
+    {
+    }
+
+    public CrossUpConfig(
+        CrossUpComponent enabled,
+        (bool, int, int) split,
+        (int, int, bool) padlock,
+        (int, int, bool) setNum,
+        (int, int) changeSet,
+        bool hideTriggerText,
+        bool hideUnassigned,
+        (int, int, Vector3) selectBG,
+        (Vector3, Vector3) buttons,
+        (Vector3, Vector3, Vector3) text,
+        bool sepEx,
+        bool onlyOneEx,
+        (int, int) lr,
+        (int, int) rl)
+    {
+        Enabled = enabled;
+        Split = split;
+        Padlock = padlock;
+        SetNum = setNum;
+        ChangeSet = changeSet;
+        HideTriggerText = hideTriggerText;
+        HideUnassigned = hideUnassigned;
+        SelectBG = selectBG;
+        Buttons = buttons;
+        Text = text;
+        SepEx = sepEx;
+        OnlyOneEx = onlyOneEx;
+        LRpos = lr;
+        RLpos = rl;
+    }
+
+    public void ApplyConfig(Plugin plugin)
+    {
+        static void Exec(string cmd, Plugin plugin)
+        {
+            PluginLog.Log($"CrossUp command: {cmd}");
+            plugin.CommandManager.ProcessCommand(cmd);
+        }
+
+        static string FloatToHex(float f) => Convert.ToHexString(BitConverter.GetBytes((uint)(f * 255)))[..2];
+        static string VecToHex(Vector3 color) => FloatToHex(color.X) + FloatToHex(color.Y) + FloatToHex(color.Z);
+
+        try
+        {
+            if (this[CrossUpComponent.Split]) Exec($"/xup split {(Split.on ? "on" : "off")} {Split.distance} {Split.center}", plugin);
+            if (this[CrossUpComponent.Padlock]) Exec($"/xup padlock {(Padlock.hide ? "off" : "on")} {Padlock.x} {Padlock.y}", plugin);
+            if (this[CrossUpComponent.SetNum]) Exec($"/xup setnum {(SetNum.hide ? "off" : "on")} {SetNum.x} {SetNum.y}", plugin);
+            if (this[CrossUpComponent.ChangeSet]) Exec($"/xup changeset {ChangeSet.x} {ChangeSet.y}", plugin);
+            if (this[CrossUpComponent.TriggerText]) Exec($"/xup triggertext {(HideTriggerText ? "off" : "on")}", plugin);
+            if (this[CrossUpComponent.Unassigned]) Exec($"/xup emptyslots {(HideUnassigned ? "off" : "on")}", plugin);
+            if (this[CrossUpComponent.SelectBG]) Exec($"/xup selectbg {SelectBG.style} {SelectBG.blend} {VecToHex(SelectBG.color)}", plugin);
+            if (this[CrossUpComponent.Buttons]) Exec($"/xup buttonglow {VecToHex(Buttons.glow)} {VecToHex(Buttons.pulse)}", plugin);
+            if (this[CrossUpComponent.Text]) Exec($"/xup text {VecToHex(Text.color)} {VecToHex(Text.glow)} {VecToHex(Text.border)}", plugin);
+            if (this[CrossUpComponent.SepEx])
+            {
+                Exec($"/xup exbar {(SepEx ? "on" : "off")}", plugin);
+                Exec($"/xup onlyone {(OnlyOneEx ? "true" : "false")}", plugin);
+            }
+            if (this[CrossUpComponent.LRpos]) Exec($"/xup lrpos {LRpos.x} {LRpos.y}", plugin);
+            if (this[CrossUpComponent.RLpos]) Exec($"/xup rlpos {RLpos.x} {RLpos.y}", plugin);
+        }
+        catch (Exception ex)
+        {
+            PluginLog.LogWarning($"Error applying CrossUp settings: {ex}");
+        }
+    }
+
+    public bool this[CrossUpComponent component]
+    {
+        get => (Enabled & component) > 0;
+        set
+        {
+            if (value) Enabled |= component;
+            else Enabled &= ~component;
+        }
+    }
+
+    public CrossUpConfig Clone() => new(Enabled, Split, Padlock, SetNum, ChangeSet, HideTriggerText, HideUnassigned,
+        SelectBG, Buttons, Text, SepEx, OnlyOneEx, LRpos, RLpos);
+
+    [Flags]
+    public enum CrossUpComponent
+    {
+        Split = 1 << 0,
+        Padlock = 1 << 1,
+        SetNum = 1 << 2,
+        ChangeSet = 1 << 3,
+        TriggerText = 1 << 4,
+        Unassigned = 1 << 5,
+        SelectBG = 1 << 6,
+        Buttons = 1 << 7,
+        Text = 1 << 8,
+        SepEx = 1 << 9,
+        LRpos = 1 << 10,
+        RLpos = 1 << 11,
+    }
+}

--- a/HUDManager/Structs/External/CrossUpConfig.cs
+++ b/HUDManager/Structs/External/CrossUpConfig.cs
@@ -62,38 +62,22 @@ public class CrossUpConfig
 
     public void ApplyConfig(Plugin plugin)
     {
-        static void Exec(string cmd, Plugin plugin)
-        {
-            PluginLog.Log($"CrossUp command: {cmd}");
-            plugin.CommandManager.ProcessCommand(cmd);
-        }
-
-        static string FloatToHex(float f) => Convert.ToHexString(BitConverter.GetBytes((uint)(f * 255)))[..2];
-        static string VecToHex(Vector3 color) => FloatToHex(color.X) + FloatToHex(color.Y) + FloatToHex(color.Z);
-
         try
         {
-            if (this[CrossUpComponent.Split]) Exec($"/xup split {(Split.on ? "on" : "off")} {Split.distance} {Split.center}", plugin);
-            if (this[CrossUpComponent.Padlock]) Exec($"/xup padlock {(Padlock.hide ? "off" : "on")} {Padlock.x} {Padlock.y}", plugin);
-            if (this[CrossUpComponent.SetNum]) Exec($"/xup setnum {(SetNum.hide ? "off" : "on")} {SetNum.x} {SetNum.y}", plugin);
-            if (this[CrossUpComponent.ChangeSet]) Exec($"/xup changeset {ChangeSet.x} {ChangeSet.y}", plugin);
-            if (this[CrossUpComponent.TriggerText]) Exec($"/xup triggertext {(HideTriggerText ? "off" : "on")}", plugin);
-            if (this[CrossUpComponent.Unassigned]) Exec($"/xup emptyslots {(HideUnassigned ? "off" : "on")}", plugin);
-            if (this[CrossUpComponent.SelectBG]) Exec($"/xup selectbg {SelectBG.style} {SelectBG.blend} {VecToHex(SelectBG.color)}", plugin);
-            if (this[CrossUpComponent.Buttons]) Exec($"/xup buttonglow {VecToHex(Buttons.glow)} {VecToHex(Buttons.pulse)}", plugin);
-            if (this[CrossUpComponent.Text]) Exec($"/xup text {VecToHex(Text.color)} {VecToHex(Text.glow)} {VecToHex(Text.border)}", plugin);
-            if (this[CrossUpComponent.SepEx])
-            {
-                Exec($"/xup exbar {(SepEx ? "on" : "off")}", plugin);
-                Exec($"/xup onlyone {(OnlyOneEx ? "true" : "false")}", plugin);
-            }
-            if (this[CrossUpComponent.LRpos]) Exec($"/xup lrpos {LRpos.x} {LRpos.y}", plugin);
-            if (this[CrossUpComponent.RLpos]) Exec($"/xup rlpos {RLpos.x} {RLpos.y}", plugin);
+            if (this[CrossUpComponent.Split]) plugin.Interface.GetIpcSubscriber<(bool, int, int), bool>("CrossUp.SplitBar").InvokeAction(Split);
+            if (this[CrossUpComponent.Padlock]) plugin.Interface.GetIpcSubscriber<(int, int, bool), bool>("CrossUp.Padlock").InvokeAction(Padlock);
+            if (this[CrossUpComponent.SetNum]) plugin.Interface.GetIpcSubscriber<(int, int, bool), bool>("CrossUp.SetNumText").InvokeAction(SetNum);
+            if (this[CrossUpComponent.ChangeSet]) plugin.Interface.GetIpcSubscriber<(int, int), bool>("CrossUp.ChangeSet").InvokeAction(ChangeSet);
+            if (this[CrossUpComponent.TriggerText]) plugin.Interface.GetIpcSubscriber<bool, bool>("CrossUp.TriggerText").InvokeAction(!HideTriggerText);
+            if (this[CrossUpComponent.Unassigned]) plugin.Interface.GetIpcSubscriber<bool, bool>("CrossUp.EmptySlots").InvokeAction(!HideUnassigned);
+            if (this[CrossUpComponent.SelectBG]) plugin.Interface.GetIpcSubscriber<(int, int, Vector3), bool>("CrossUp.SelectBG").InvokeAction(SelectBG);
+            if (this[CrossUpComponent.Buttons]) plugin.Interface.GetIpcSubscriber<(Vector3, Vector3), bool>("CrossUp.ButtonGlow").InvokeAction(Buttons);
+            if (this[CrossUpComponent.Text]) plugin.Interface.GetIpcSubscriber<(Vector3, Vector3, Vector3), bool>("CrossUp.TextAndBorders").InvokeAction(Text);
+            if (this[CrossUpComponent.SepEx]) plugin.Interface.GetIpcSubscriber<(bool, bool), bool>("CrossUp.ExBar").InvokeAction((SepEx, OnlyOneEx));
+            if (this[CrossUpComponent.LRpos]) plugin.Interface.GetIpcSubscriber<(int, int), bool>("CrossUp.LRpos").InvokeAction(LRpos);
+            if (this[CrossUpComponent.RLpos]) plugin.Interface.GetIpcSubscriber<(int, int), bool>("CrossUp.RLpos").InvokeAction(RLpos);
         }
-        catch (Exception ex)
-        {
-            PluginLog.LogWarning($"Error applying CrossUp settings: {ex}");
-        }
+        catch { PluginLog.LogWarning($"IPC with CrossUp failed. Is CrossUp installed?"); }
     }
 
     public bool this[CrossUpComponent component]
@@ -105,7 +89,6 @@ public class CrossUpConfig
             else Enabled &= ~component;
         }
     }
-
     public CrossUpConfig Clone() => new(Enabled, Split, Padlock, SetNum, ChangeSet, HideTriggerText, HideUnassigned,
         SelectBG, Buttons, Text, SepEx, OnlyOneEx, LRpos, RLpos);
 

--- a/HUDManager/Structs/External/CrossUpConfig.cs
+++ b/HUDManager/Structs/External/CrossUpConfig.cs
@@ -60,6 +60,20 @@ public class CrossUpConfig
         RLpos = rl;
     }
 
+    public void OpenCrossUp(ref Plugin plugin)
+    {
+
+        try
+        {
+            plugin.Interface.GetIpcSubscriber<bool>("CrossUp.Open").InvokeAction();
+        }
+        catch
+        {
+           PluginLog.LogWarning("IPC with CrossUp failed. Is CrossUp installed?");
+        }
+    
+    }
+
     public void ApplyConfig(Plugin plugin)
     {
         try
@@ -77,7 +91,7 @@ public class CrossUpConfig
             if (this[CrossUpComponent.LRpos]) plugin.Interface.GetIpcSubscriber<(int, int), bool>("CrossUp.LRpos").InvokeAction(LRpos);
             if (this[CrossUpComponent.RLpos]) plugin.Interface.GetIpcSubscriber<(int, int), bool>("CrossUp.RLpos").InvokeAction(RLpos);
         }
-        catch { PluginLog.LogWarning($"IPC with CrossUp failed. Is CrossUp installed?"); }
+        catch { PluginLog.LogWarning("IPC with CrossUp failed. Is CrossUp installed?"); }
     }
 
     public bool this[CrossUpComponent component]
@@ -106,6 +120,6 @@ public class CrossUpConfig
         Text = 1 << 8,
         SepEx = 1 << 9,
         LRpos = 1 << 10,
-        RLpos = 1 << 11,
+        RLpos = 1 << 11
     }
 }

--- a/HUDManager/Ui/Editor/LayoutEditor.cs
+++ b/HUDManager/Ui/Editor/LayoutEditor.cs
@@ -38,7 +38,7 @@ namespace HUD_Manager.Ui.Editor
             this.Previews = new Previews(plugin, ui);
             this.HudElements = new HudElements(plugin, ui, this);
             this.Windows = new Windows(plugin);
-            this.ExternalElements = new ExternalElements(plugin);
+            this.ExternalElements = new ExternalElements(plugin, ui);
         }
 
         internal void Draw()

--- a/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
+++ b/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dalamud.Interface;
 using HUD_Manager;
@@ -13,7 +14,13 @@ internal partial class ExternalElements
 {
     public sealed class Browsingway : IExternalElement
     {
-        public bool Available(Plugin plugin) => plugin.Interface.PluginNames.Contains("Browsingway");
+        public Plugin Plugin;
+        public Browsingway(Plugin plugin)
+        {
+            Plugin = plugin;
+        }
+
+        public bool Available() => Plugin.Interface.PluginNames.Contains("Browsingway");
 
         public void AddButtonToList(SavedLayout layout, ref bool update, bool avail)
         {
@@ -24,10 +31,7 @@ internal partial class ExternalElements
 
             ImGui.SameLine();
 
-            if (avail)
-                 ImGui.Text("Browsingway");
-            else
-                 ImGui.TextDisabled("Browsingway (not installed)");
+            ((Action<string>)(avail ? ImGui.Text : ImGui.TextDisabled)).Invoke(avail ? "Browsingway" : "Browsingway (not installed)");
 
             ImGui.SameLine();
             ImGuiExt.HelpMarker("Install the Browsingway plugin before use. You can set up changes to Browsingway overlays using this menu.");

--- a/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
+++ b/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Dalamud.Interface;
+using HUD_Manager;
 using HUD_Manager.Configuration;
 using HUD_Manager.Ui;
 using HUDManager.Structs.External;
@@ -12,7 +13,9 @@ internal partial class ExternalElements
 {
     public sealed class Browsingway : IExternalElement
     {
-        public void AddButtonToList(SavedLayout layout, ref bool update)
+        public bool Available(Plugin plugin) => plugin.Interface.PluginNames.Contains("Browsingway");
+
+        public void AddButtonToList(SavedLayout layout, ref bool update, bool avail)
         {
             if (ImGuiExt.IconButton(FontAwesomeIcon.Plus, "uimanager-add-browsingway"))
             {
@@ -20,7 +23,12 @@ internal partial class ExternalElements
             }
 
             ImGui.SameLine();
-            ImGui.Text("Browsingway");
+
+            if (avail)
+                 ImGui.Text("Browsingway");
+            else
+                 ImGui.TextDisabled("Browsingway (not installed)");
+
             ImGui.SameLine();
             ImGuiExt.HelpMarker("Install the Browsingway plugin before use. You can set up changes to Browsingway overlays using this menu.");
         }
@@ -30,7 +38,7 @@ internal partial class ExternalElements
 
             foreach (var (overlay, i) in layout.BrowsingwayOverlays.Select((overlay, i) => (overlay, i)))
             {
-                if (!ImGui.CollapsingHeader($"{overlay.CommandName}###bw-overlay-{i}"))
+                if (!ImGui.CollapsingHeader($"Browsingway: {overlay.CommandName}###bw-overlay-{i}"))
                 {
                     continue;
                 }

--- a/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
+++ b/HUDManager/Ui/Editor/Tabs/External/Browsingway.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Interface;
+using HUD_Manager.Configuration;
+using HUD_Manager.Ui;
+using HUDManager.Structs.External;
+using ImGuiNET;
+
+namespace HUDManager.Ui.Editor.Tabs;
+
+internal partial class ExternalElements
+{
+    public sealed class Browsingway : IExternalElement
+    {
+        public void AddButtonToList(SavedLayout layout, ref bool update)
+        {
+            if (ImGuiExt.IconButton(FontAwesomeIcon.Plus, "uimanager-add-browsingway"))
+            {
+                layout.BrowsingwayOverlays.Add(new BrowsingwayOverlay());
+            }
+
+            ImGui.SameLine();
+            ImGui.Text("Browsingway");
+            ImGui.SameLine();
+            ImGuiExt.HelpMarker("Install the Browsingway plugin before use. You can set up changes to Browsingway overlays using this menu.");
+        }
+        public void DrawControls(SavedLayout layout, ref bool update)
+        {
+            List<BrowsingwayOverlay> toRemove = new();
+
+            foreach (var (overlay, i) in layout.BrowsingwayOverlays.Select((overlay, i) => (overlay, i)))
+            {
+                if (!ImGui.CollapsingHeader($"{overlay.CommandName}###bw-overlay-{i}"))
+                {
+                    continue;
+                }
+
+                const ImGuiTableFlags flags = ImGuiTableFlags.BordersInner
+                                              | ImGuiTableFlags.PadOuterX
+                                              | ImGuiTableFlags.SizingFixedFit
+                                              | ImGuiTableFlags.RowBg;
+
+                if (!ImGui.BeginTable($"bw-overlay-table-{i}", 3, flags))
+                {
+                    continue;
+                }
+
+                ImGui.TableSetupColumn("Enabled");
+                ImGui.TableSetupColumn("Setting");
+                ImGui.TableSetupColumn("Control", ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableHeadersRow();
+
+                ImGui.SameLine(ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 3);
+                if (ImGuiExt.IconButton(FontAwesomeIcon.TrashAlt, $"bw-overlay-remove-{i}"))
+                {
+                    toRemove.Add(overlay);
+                    update = true;
+                }
+
+                ImGuiExt.HoverTooltip("Remove this element from this layout");
+
+                ImGui.TableNextRow();
+
+                static void DrawSettingName(string name)
+                {
+                    ImGui.TextUnformatted(name);
+                    ImGui.TableNextColumn();
+                }
+
+                void DrawEnabledCheckbox(BrowsingwayOverlay.BrowsingwayOverlayComponent component, ref bool update1,
+                    bool nextCol = true)
+                {
+                    if (nextCol)
+                    {
+                        ImGui.TableNextColumn();
+                    }
+
+                    var enabled = overlay[component];
+                    if (ImGui.Checkbox($"###bw-{component}-enabled-{i}", ref enabled))
+                    {
+                        overlay[component] = enabled;
+                        update1 = true;
+                    }
+
+                    ImGui.TableNextColumn();
+                }
+
+                // Name setting
+                ImGui.TableSetColumnIndex(1);
+                DrawSettingName("Name");
+                if (ImGui.InputText($"###bw-name-{i}", ref overlay.CommandName, 128))
+                {
+                    update = true;
+                }
+
+                ImGui.TableNextRow();
+                ImGui.TableSetColumnIndex(0);
+
+                void DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent component, string settingName,
+                    ref bool setting, ref bool update2)
+                {
+                    ImGui.TableSetColumnIndex(0);
+
+                    DrawEnabledCheckbox(component, ref update2, false);
+                    DrawSettingName(settingName);
+                    if (ImGui.Checkbox($"###bw-{settingName}-{i}", ref setting))
+                    {
+                        update2 = true;
+                    }
+
+                    ImGui.TableNextRow();
+                }
+
+                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Hidden, "Hidden", ref overlay.Hidden, ref update);
+                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Locked, "Locked", ref overlay.Locked, ref update);
+                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Typethrough, "Typethrough", ref overlay.Typethrough, ref update);
+                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Clickthrough, "Clickthrough", ref overlay.Clickthrough, ref update);
+
+                ImGui.EndTable();
+            }
+
+            foreach (var overlay in toRemove)
+            {
+                layout.BrowsingwayOverlays.Remove(overlay);
+            }
+        }
+
+    }
+}

--- a/HUDManager/Ui/Editor/Tabs/External/CrossUp.cs
+++ b/HUDManager/Ui/Editor/Tabs/External/CrossUp.cs
@@ -2,34 +2,41 @@
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
-using HUD_Manager.Configuration;
 using HUD_Manager;
+using HUD_Manager.Configuration;
 using HUD_Manager.Ui;
+using HUDManager.Structs.External;
 using ImGuiNET;
+using static Dalamud.Interface.FontAwesomeIcon;
 using static HUDManager.Structs.External.CrossUpConfig;
-
 
 namespace HUDManager.Ui.Editor.Tabs;
 internal partial class ExternalElements
 {
     public sealed class CrossUp : IExternalElement
     {
-        public bool Available(Plugin plugin)
+        public static Plugin Plugin = null!;
+
+        public CrossUp(Plugin plugin)
+        {
+            Plugin = plugin;
+        }
+
+        public bool Available()
         {
             try
             {
-                return plugin.Interface.PluginNames.Contains("CrossUp") && plugin.Interface.GetIpcSubscriber<bool>("CrossUp.Available").InvokeFunc();
+                return Plugin.Interface.PluginNames.Contains("CrossUp") && Plugin.Interface.GetIpcSubscriber<bool>("CrossUp.Available").InvokeFunc();
             }
             catch
             {
                 return false;
             }
         }
-
         public void AddButtonToList(SavedLayout layout, ref bool update, bool avail)
         {
             var exists = layout.CrossUpConfig != null;
-            var icon = exists ? FontAwesomeIcon.TrashAlt : FontAwesomeIcon.Plus;
+            var icon = exists ? TrashAlt : Plus;
             var label = $"uimanager-{(exists ? "remove" : "add")}-crossup";
 
             if (ImGuiExt.IconButton(icon, label))
@@ -39,11 +46,7 @@ internal partial class ExternalElements
             }
 
             ImGui.SameLine();
-
-            if (avail)
-                ImGui.Text("CrossUp");
-            else
-                ImGui.TextDisabled("CrossUp (not installed)");
+            ((Action<string>)(avail ? ImGui.Text : ImGui.TextDisabled)).Invoke(avail ? "CrossUp" : "CrossUp (not installed)");
 
             ImGui.SameLine();
             ImGuiExt.HelpMarker("CrossUp is a plugin that enables additional customization and features for the Cross Hotbar. If you have the CrossUp plugin installed, you can use HUD Manager layouts to manipulate your CrossUp settings.");
@@ -51,642 +54,629 @@ internal partial class ExternalElements
 
         public void DrawControls(SavedLayout layout, ref bool update)
         {
-            if (layout.CrossUpConfig == null || !ImGui.CollapsingHeader("CrossUp Settings##xup")) {return;}
+            var config = layout.CrossUpConfig;
+            if (config == null || !ImGui.CollapsingHeader("CrossUp Settings##xup")) {return;}
+
+            if (!ImGui.BeginTabBar("CrossUpTabs",ImGuiTabBarFlags.FittingPolicyDefault)) return;
             
-            const ImGuiTableFlags tableFlags = ImGuiTableFlags.Borders | ImGuiTableFlags.PadOuterX |
-                                               ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg;
-            const ImGuiColorEditFlags pickerFlags = ImGuiColorEditFlags.PickerMask | ImGuiColorEditFlags.DisplayHex;
-
-            if (ImGui.BeginTabBar("CrossUpTabs"))
-            {
-                if (ImGui.BeginTabItem("Cross Hotbar Layout"))
-                {
-                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
-                    {
-                        SetupColumns();
-
-                        ImGui.Indent(15f * Scale);
-                        LRSplit(ref update);
-                        Padlock(ref update);
-                        SetNumText(ref update);
-                        ChangeSetDisplay(ref update);
-                        TriggerText(ref update);
-                        UnassignedSlots(ref update);
-                        ImGui.Indent(-15f * Scale);
-
-                        ImGui.EndTable();
-                    }
-
-                    ImGui.EndTabItem();
-                }
-
-                if (ImGui.BeginTabItem("Colors"))
-                {
-                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
-                    {
-                        SetupColumns();
-
-                        ImGui.Indent(15f * Scale);
-                        SelectBG(ref update);
-                        Buttons(ref update);
-                        TextColor(ref update);
-                        ImGui.Indent(-15f * Scale);
-
-                        ImGui.EndTable();
-                    }
-
-                    ImGui.EndTabItem();
-                }
-
-                if (ImGui.BeginTabItem("Expanded Hold Controls"))
-                {
-                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
-                    {
-                        SetupColumns();
-
-                        ImGui.Indent(15f * Scale);
-                        SeparateEx(ref update);
-                        LRpos(ref update);
-                        if (!layout.CrossUpConfig.OnlyOneEx) RLpos(ref update);
-                        ImGui.Indent(-15f * Scale);
-
-                        ImGui.EndTable();
-                    }
-
-                    ImGui.EndTabItem();
-                }
+            Tabs.BarLayout(ref config, ref update);
+            Tabs.Color(ref config, ref update);
+            Tabs.Exhb(ref config, ref update);
                 
+            ImGui.PushFont(UiBuilder.IconFont);
+            ImGui.SetNextItemWidth(40f*Scale);
 
-                
-                ImGui.PushFont(UiBuilder.IconFont);
-                ImGui.SetNextItemWidth(23f*Scale);
-                if (ImGui.TabItemButton($"{FontAwesomeIcon.TrashAlt.ToIconString()}##xup-overlay-remove"))
-                {
-                    layout.CrossUpConfig = null;
-                    update = true;
-                }
-                ImGui.PopFont();
-                ImGuiExt.HoverTooltip("Remove CrossUp settings from this layout");
-
-                ImGui.EndTabBar();
-            }
-
-            static void SetupColumns()
+            if (ImGui.TabItemButton($"{Cog.ToIconString()}{AngleDoubleRight.ToIconString()}##xup-open"))
             {
-                ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed, 50 * Scale);
-                ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch);
-                ImGui.TableHeadersRow();
+                layout.CrossUpConfig!.OpenCrossUp(ref Plugin);
             }
+            ImGui.PopFont();
+            ImGuiExt.HoverTooltip("Open CrossUp");
 
-            void DrawEnabledCheckbox(CrossUpComponent component, ref bool update)
+            ImGui.PushFont(UiBuilder.IconFont);
+            ImGui.SetNextItemWidth(23f * Scale);
+            if (ImGui.TabItemButton($"{TrashAlt.ToIconString()}##xup-overlay-remove"))
             {
-                var enabled = layout.CrossUpConfig[component];
-                if (!ImGui.Checkbox($"###xup-{component}-enabled", ref enabled)) return;
-                layout.CrossUpConfig[component] = enabled;
+                layout.CrossUpConfig = null;
                 update = true;
             }
+            ImGui.PopFont();
+            ImGuiExt.HoverTooltip("Remove CrossUp settings from this layout");
 
-            void LRSplit(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                ImGui.Spacing();
-                DrawEnabledCheckbox(CrossUpComponent.Split, ref update);
-
-                ImGui.TableNextColumn();
-
-                ImGui.BeginGroup();
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, "BAR SEPARATION");
-
-                ImGui.Text("Separate Left/Right");
-                ImGui.SameLine(160f * Scale);
-                if (ImGui.Checkbox("##xup-splitOn", ref layout.CrossUpConfig.Split.on)) update = true;
-
-                if (layout.CrossUpConfig.Split.on)
-                {
-                    ImGui.Text("Separation Distance");
-                    ImGui.SameLine(160f * Scale);
-                    ImGui.PushID("xup-resetSplit");
-                    if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                    {
-                        layout.CrossUpConfig.Split.distance = 100;
-                        update = true;
-                    }
-
-                    ImGui.PopID();
-                    ImGui.SameLine();
-                    ImGui.SetNextItemWidth(90 * Scale);
-                    if (ImGui.InputInt("##xup-splitDistance", ref layout.CrossUpConfig.Split.distance))
-                    {
-                        layout.CrossUpConfig.Split.distance =
-                            Math.Max(layout.CrossUpConfig.Split.distance, -142);
-                        update = true;
-                    }
-
-
-                    ImGui.Text("Center Point");
-                    ImGui.SameLine(160f * Scale);
-
-                    ImGui.PushID("xup-resetCenter");
-                    if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                    {
-                        layout.CrossUpConfig.Split.center = 0;
-                        update = true;
-                    }
-
-                    ImGui.PopID();
-                    ImGui.SameLine();
-                    ImGui.SetNextItemWidth(90 * Scale);
-                    if (ImGui.InputInt("##xup-centerPoint", ref layout.CrossUpConfig.Split.center))
-                        update = true;
-
-                    ImGuiComponents.HelpMarker(
-                        "This will override your HUD setting for the bar's horizontal position.");
-                }
-
-                ImGui.EndGroup();
-            }
-
-            void Padlock(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                DrawEnabledCheckbox(CrossUpComponent.Padlock, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("Padlock Icon");
-
-                ImGui.SameLine(160f * Scale);
-
-                ImGui.PushID("xup-resetPadlock");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Padlock = (0, 0, false);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-padlockX", ref layout.CrossUpConfig.Padlock.x)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltH, true);
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-padlockY", ref layout.CrossUpConfig.Padlock.y)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltV, true);
-
-                ImGui.SameLine();
-                if (ImGui.Checkbox("Hide##xup-hidePadlock", ref layout.CrossUpConfig.Padlock.hide))
-                    update = true;
-
-                ImGui.EndGroup();
-            }
-
-            void SetNumText(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                DrawEnabledCheckbox(CrossUpComponent.SetNum, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("SET # Text");
-
-                ImGui.SameLine(160f * Scale);
-
-                ImGui.PushID("xup-resetSetNumText");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.SetNum = (0, 0, false);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-setNumTextX", ref layout.CrossUpConfig.SetNum.x)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltH, true);
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-SetNumTextY", ref layout.CrossUpConfig.SetNum.y)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltV, true);
-
-                ImGui.SameLine();
-                if (ImGui.Checkbox("Hide##xup-hideSetNumText", ref layout.CrossUpConfig.SetNum.hide))
-                    update = true;
-
-                ImGui.EndGroup();
-            }
-
-            void ChangeSetDisplay(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                DrawEnabledCheckbox(CrossUpComponent.ChangeSet, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("CHANGE SET Display");
-
-                ImGui.SameLine(160f * Scale);
-
-                ImGui.PushID("xup-resetChangeSet");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.ChangeSet = (0, 0);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-changeSetX", ref layout.CrossUpConfig.ChangeSet.x)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltH, true);
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(90 * Scale);
-                if (ImGui.InputInt("##xup-changeSetY", ref layout.CrossUpConfig.ChangeSet.y)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltV, true);
-
-                ImGui.EndGroup();
-            }
-
-            void TriggerText(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                DrawEnabledCheckbox(CrossUpComponent.TriggerText, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("Hide L/R Trigger Text");
-                ImGui.SameLine(160f * Scale);
-
-                if (ImGui.Checkbox("##xup-hideTriggerText", ref layout.CrossUpConfig.HideTriggerText))
-                    update = true;
-
-                ImGui.EndGroup();
-            }
-
-            void UnassignedSlots(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                DrawEnabledCheckbox(CrossUpComponent.Unassigned, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("Hide Unassigned Slots");
-                ImGui.SameLine(160f * Scale);
-
-                if (ImGui.Checkbox("##xup-hideUnassigned", ref layout.CrossUpConfig.HideUnassigned))
-                    update = true;
-                ImGui.EndGroup();
-            }
-
-            void SelectBG(ref bool update)
-            {
-                var solid = layout.CrossUpConfig.SelectBG.style == 0;
-                var frame = layout.CrossUpConfig.SelectBG.style == 1;
-                var hidden = layout.CrossUpConfig.SelectBG.style == 2;
-                var normal = layout.CrossUpConfig.SelectBG.blend == 0;
-                var dodge = layout.CrossUpConfig.SelectBG.blend == 2;
-
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                ImGui.Spacing();
-                DrawEnabledCheckbox(CrossUpComponent.SelectBG, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, "SELECTED BAR");
-
-                ImGui.Text("Backdrop Color");
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetBG");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.SelectBG.color = new(100f / 255f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-bgColor", ref layout.CrossUpConfig.SelectBG.color, pickerFlags))
-                    update = true;
-
-                ImGui.Text("Backdrop Style");
-                ImGui.SameLine(160f * Scale);
-                if (ImGui.RadioButton("Solid##xup-bgStyle0", solid))
-                {
-                    layout.CrossUpConfig.SelectBG.style = 0;
-                    update = true;
-                }
-
-                ImGui.SameLine();
-                if (ImGui.RadioButton("Frame##xup-bgStyle1", frame))
-                {
-                    layout.CrossUpConfig.SelectBG.style = 1;
-                    update = true;
-                }
-
-                ImGui.SameLine();
-                if (ImGui.RadioButton("Hidden##xup-bgStyle2", hidden))
-                {
-                    layout.CrossUpConfig.SelectBG.style = 2;
-                    update = true;
-                }
-
-                ImGui.Text("Color Blending");
-                ImGui.SameLine(160f * Scale);
-                if (ImGui.RadioButton("Normal##xup-bgBlend0", normal))
-                {
-                    layout.CrossUpConfig.SelectBG.blend = 0;
-                    update = true;
-                }
-
-                ImGui.SameLine();
-                if (ImGui.RadioButton("Dodge##xup-bgBlend2", dodge))
-                {
-                    layout.CrossUpConfig.SelectBG.blend = 2;
-                    update = true;
-                }
-
-                ImGui.EndGroup();
-            }
-
-            void Buttons(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                ImGui.Spacing();
-                DrawEnabledCheckbox(CrossUpComponent.Buttons, ref update);
-                ImGui.TableNextColumn();
-
-                ImGui.BeginGroup();
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, "BUTTONS");
-
-
-                ImGui.Text("Button Glow");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetButtonGlow");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Buttons.glow = new(1f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-buttonGlow", ref layout.CrossUpConfig.Buttons.glow, pickerFlags))
-                    update = true;
-
-
-                ImGui.Text("Button Pulse");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetButtonPulse");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Buttons.pulse = new(1f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-ButtonPulse", ref layout.CrossUpConfig.Buttons.pulse, pickerFlags))
-                    update = true;
-
-                ImGui.EndGroup();
-            }
-
-            void TextColor(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                ImGui.Spacing();
-                DrawEnabledCheckbox(CrossUpComponent.Text, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, "TEXT & BORDERS");
-
-
-                ImGui.Text("Text Color");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetTextColor");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Text.color = new(1f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-textColor", ref layout.CrossUpConfig.Text.color, pickerFlags))
-                    update = true;
-
-
-                ImGui.Text("Text Glow");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetTextGlow");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Text.glow = new(0.616f, 0.514f, 0.357f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-textGlow", ref layout.CrossUpConfig.Text.glow, pickerFlags))
-                    update = true;
-
-
-                ImGui.Text("Border Color");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-resetBorder");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.Text.border = new(1f);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.ColorEdit3("##xup-border", ref layout.CrossUpConfig.Text.border, pickerFlags))
-                    update = true;
-
-                ImGui.EndGroup();
-            }
-
-            void SeparateEx(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-
-                ImGui.Spacing();
-                DrawEnabledCheckbox(CrossUpComponent.SepEx, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, "EXPANDED HOLD CONTROLS");
-                if (ImGui.Checkbox("Display Expanded Hold Controls Separately##xup-sepEx",
-                        ref layout.CrossUpConfig.SepEx)) update = true;
-
-                ImGuiComponents.HelpMarker(
-                    "NOTE: This feature functions by borrowing the buttons from two of your standard mouse/keyboard hotbars. Please use CrossUp's plugin configuration to select which bars to borrow.\n\nThe hotbars you choose will not be overwritten, but they will be unavailable while the feature is active.");
-
-
-                if (ImGui.RadioButton("Show Only One Bar##xup-onlyone", layout.CrossUpConfig.OnlyOneEx))
-                {
-                    layout.CrossUpConfig.OnlyOneEx = true;
-                    update = true;
-                }
-                
-                if (ImGui.RadioButton("Show Both##xup-showBoth", !layout.CrossUpConfig.OnlyOneEx))
-                {
-                    layout.CrossUpConfig.OnlyOneEx = false;
-                    update = true;
-                }
-
-
-                ImGui.EndGroup();
-            }
-
-            void LRpos(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                DrawEnabledCheckbox(CrossUpComponent.LRpos, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text($"{(layout.CrossUpConfig.OnlyOneEx ? "" : "L→R ")}Bar Position");
-                ImGui.SameLine();
-                ImGuiComponents.HelpMarker(
-                    "Position is relative to the center of the Cross Hotbar.\n\nDefault: (-214, -88), which matches the Left WXHB's default location.");
-
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-lrReset");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.LRpos = (-214, -88);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.InputInt("##xup-lrX", ref layout.CrossUpConfig.LRpos.x)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltH, true);
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.InputInt("##xup-lrY", ref layout.CrossUpConfig.LRpos.y)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltV, true);
-
-                ImGui.EndGroup();
-            }
-
-            void RLpos(ref bool update)
-            {
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                DrawEnabledCheckbox(CrossUpComponent.RLpos, ref update);
-
-                ImGui.TableNextColumn();
-                ImGui.BeginGroup();
-
-                ImGui.Text("R→L Bar Position");
-                ImGui.SameLine();
-                ImGuiComponents.HelpMarker(
-                    "Position is relative to the center of the Cross Hotbar.\n\nDefault: (214, -88), which matches the Right WXHB's default location.");
-
-                ImGui.SameLine(160f * Scale);
-                ImGui.PushID("xup-rlReset");
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
-                {
-                    layout.CrossUpConfig.RLpos = (214, -88);
-                    update = true;
-                }
-
-                ImGui.PopID();
-
-                ImGui.SameLine();
-
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.InputInt("##xup-rlX", ref layout.CrossUpConfig.RLpos.x)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltH, true);
-
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(100 * Scale);
-                if (ImGui.InputInt("##xup-rlY", ref layout.CrossUpConfig.RLpos.y)) update = true;
-
-                WriteIcon(FontAwesomeIcon.ArrowsAltV, true);
-
-                ImGui.EndGroup();
-            }
+            ImGui.EndTabBar();
         }
 
-        public static void WriteIcon(FontAwesomeIcon icon, bool sameLine = false)
+        private const ImGuiTableFlags TableFlags = ImGuiTableFlags.Borders | ImGuiTableFlags.PadOuterX | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg;
+        private const ImGuiColorEditFlags PickerFlags = ImGuiColorEditFlags.PickerMask | ImGuiColorEditFlags.DisplayHex;
+
+        public class Tabs
+        {
+            public static void BarLayout(ref CrossUpConfig config, ref bool update)
+            {
+
+                if (!ImGui.BeginTabItem("Cross Hotbar Layout")) return;
+
+                if (ImGui.BeginTable("CrossUpTable", 2, TableFlags))
+                {
+                    SetUpColumns();
+
+                    ImGui.Indent(15f * Scale);
+                    Rows.SplitBar(ref config, ref update);
+                    Rows.Padlock(ref config, ref update);
+                    Rows.SetNum(ref config, ref update);
+                    Rows.ChangeSet(ref config, ref update);
+                    Rows.TriggerText(ref config, ref update);
+                    Rows.UnassignedSlots(ref config, ref update);
+                    ImGui.Indent(-15f * Scale);
+
+                    ImGui.EndTable();
+                }
+
+                ImGui.EndTabItem();
+            }
+            public static void Color(ref CrossUpConfig config, ref bool update)
+            {
+                if (!ImGui.BeginTabItem("Colors")) return;
+
+                if (ImGui.BeginTable("CrossUpTable", 2, TableFlags))
+                {
+                    SetUpColumns();
+
+                    ImGui.Indent(15f * Scale);
+                    Rows.SelectBg(ref config, ref update);
+                    Rows.ButtonColor(ref config, ref update);
+                    Rows.TextAndBorder(ref config, ref update);
+                    ImGui.Indent(-15f * Scale);
+
+                    ImGui.EndTable();
+                }
+
+                ImGui.EndTabItem();
+            }
+            public static void Exhb(ref CrossUpConfig config, ref bool update)
+            {
+                if (!ImGui.BeginTabItem("Expanded Hold Controls")) return;
+
+                if (ImGui.BeginTable("CrossUpTable", 2, TableFlags))
+                {
+                    SetUpColumns();
+
+                    ImGui.Indent(15f * Scale);
+                    Rows.SepEx(ref config, ref update);
+                    Rows.LRpos(ref config, ref update);
+                    if (!config.OnlyOneEx) Rows.RLpos(ref config, ref update);
+                    ImGui.Indent(-15f * Scale);
+
+                    ImGui.EndTable();
+                }
+
+                ImGui.EndTabItem();
+            }
+
+            public class Rows
+            {
+                public static void SplitBar(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    ImGui.Spacing();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.Split, ref update);
+
+                    ImGui.TableNextColumn();
+
+                    ImGui.BeginGroup();
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, "BAR SEPARATION");
+
+                    ImGui.Text("Separate Left/Right");
+                    ImGui.SameLine(160f * Scale);
+                    if (ImGui.Checkbox("##xup-splitOn", ref config.Split.on)) update = true;
+
+                    if (config.Split.on)
+                    {
+                        ImGui.Text("Separation Distance");
+                        ImGui.SameLine(160f * Scale);
+                        ImGui.PushID("xup-resetSplit");
+                        if (ImGuiComponents.IconButton(UndoAlt))
+                        {
+                            config.Split.distance = 100;
+                            update = true;
+                        }
+
+                        ImGui.PopID();
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(90 * Scale);
+                        if (ImGui.InputInt("##xup-splitDistance", ref config.Split.distance))
+                        {
+                            config.Split.distance = Math.Max(config.Split.distance, -142);
+                            update = true;
+                        }
+
+                        ImGui.Text("Center Point");
+                        ImGui.SameLine(160f * Scale);
+
+                        ImGui.PushID("xup-resetCenter");
+                        if (ImGuiComponents.IconButton(UndoAlt))
+                        {
+                            config.Split.center = 0;
+                            update = true;
+                        }
+
+                        ImGui.PopID();
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(90 * Scale);
+                        if (ImGui.InputInt("##xup-centerPoint", ref config.Split.center)) update = true;
+
+                        ImGuiComponents.HelpMarker("This will override your HUD setting for the bar's horizontal position.");
+                    }
+
+                    ImGui.EndGroup();
+                }
+                public static void Padlock(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.Padlock, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("Padlock Icon");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetPadlock");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Padlock = (0, 0, false);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-padlockX", ref config.Padlock.x)) update = true;
+
+                    WriteIcon(ArrowsAltH, true);
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-padlockY", ref config.Padlock.y)) update = true;
+
+                    WriteIcon(ArrowsAltV, true);
+
+                    ImGui.SameLine();
+                    if (ImGui.Checkbox("Hide##xup-hidePadlock", ref config.Padlock.hide)) update = true;
+
+                    ImGui.EndGroup();
+                }
+                public static void SetNum(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.SetNum, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("SET # Text");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetSetNumText");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.SetNum = (0, 0, false);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-setNumTextX", ref config.SetNum.x)) update = true;
+
+                    WriteIcon(ArrowsAltH, true);
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-SetNumTextY", ref config.SetNum.y)) update = true;
+
+                    WriteIcon(ArrowsAltV, true);
+
+                    ImGui.SameLine();
+                    if (ImGui.Checkbox("Hide##xup-hideSetNumText", ref config.SetNum.hide)) update = true;
+
+                    ImGui.EndGroup();
+                }
+                public static void ChangeSet(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.ChangeSet, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("CHANGE SET Display");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetChangeSet");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.ChangeSet = (0, 0);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-changeSetX", ref config.ChangeSet.x)) update = true;
+
+                    WriteIcon(ArrowsAltH, true);
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-changeSetY", ref config.ChangeSet.y)) update = true;
+
+                    WriteIcon(ArrowsAltV, true);
+
+                    ImGui.EndGroup();
+                }
+                public static void TriggerText(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.TriggerText, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("Hide L/R Trigger Text");
+                    ImGui.SameLine(160f * Scale);
+
+                    if (ImGui.Checkbox("##xup-hideTriggerText", ref config.HideTriggerText)) update = true;
+
+                    ImGui.EndGroup();
+                }
+                public static void UnassignedSlots(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.Unassigned, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("Hide Unassigned Slots");
+                    ImGui.SameLine(160f * Scale);
+
+                    if (ImGui.Checkbox("##xup-hideUnassigned", ref config.HideUnassigned)) update = true;
+                    ImGui.EndGroup();
+                }
+                public static void SelectBg(ref CrossUpConfig config, ref bool update)
+                {
+                    var solid = config.SelectBG.style == 0;
+                    var frame = config.SelectBG.style == 1;
+
+                    var hidden = config.SelectBG.style == 2;
+                    var normal = config.SelectBG.blend == 0;
+                    var dodge = config.SelectBG.blend == 2;
+
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    ImGui.Spacing();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.SelectBG, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, "SELECTED BAR");
+
+                    ImGui.Text("Backdrop Color");
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetBG");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.SelectBG.color = new(100f / 255f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-bgColor", ref config.SelectBG.color, PickerFlags))
+                        update = true;
+
+                    ImGui.Text("Backdrop Style");
+                    ImGui.SameLine(160f * Scale);
+                    if (ImGui.RadioButton("Solid##xup-bgStyle0", solid))
+                    {
+                        config.SelectBG.style = 0;
+                        update = true;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.RadioButton("Frame##xup-bgStyle1", frame))
+                    {
+                        config.SelectBG.style = 1;
+                        update = true;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.RadioButton("Hidden##xup-bgStyle2", hidden))
+                    {
+                        config.SelectBG.style = 2;
+                        update = true;
+                    }
+
+                    ImGui.Text("Color Blending");
+                    ImGui.SameLine(160f * Scale);
+                    if (ImGui.RadioButton("Normal##xup-bgBlend0", normal))
+                    {
+                        config.SelectBG.blend = 0;
+                        update = true;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.RadioButton("Dodge##xup-bgBlend2", dodge))
+                    {
+                        config.SelectBG.blend = 2;
+                        update = true;
+                    }
+
+                    ImGui.EndGroup();
+                }
+                public static void ButtonColor(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    ImGui.Spacing();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.Buttons, ref update);
+                    ImGui.TableNextColumn();
+
+                    ImGui.BeginGroup();
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, "BUTTONS");
+
+
+                    ImGui.Text("Button Glow");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetButtonGlow");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Buttons.glow = new(1f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-buttonGlow", ref config.Buttons.glow, PickerFlags)) update = true;
+
+
+                    ImGui.Text("Button Pulse");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetButtonPulse");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Buttons.pulse = new(1f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-ButtonPulse", ref config.Buttons.pulse, PickerFlags)) update = true;
+
+                    ImGui.EndGroup();
+                }
+                public static void TextAndBorder(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    ImGui.Spacing();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.Text, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, "TEXT & BORDERS");
+
+
+                    ImGui.Text("Text Color");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetTextColor");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Text.color = new(1f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-textColor", ref config.Text.color, PickerFlags)) update = true;
+
+
+                    ImGui.Text("Text Glow");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetTextGlow");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Text.glow = new(0.616f, 0.514f, 0.357f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-textGlow", ref config.Text.glow, PickerFlags)) update = true;
+
+
+                    ImGui.Text("Border Color");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetBorder");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.Text.border = new(1f);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.ColorEdit3("##xup-border", ref config.Text.border, PickerFlags)) update = true;
+
+                    ImGui.EndGroup();
+                }
+                public static void SepEx(ref CrossUpConfig config, ref bool update)
+                {
+
+
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    ImGui.Spacing();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.SepEx, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, "EXPANDED HOLD CONTROLS");
+                    if (ImGui.Checkbox("Display Expanded Hold Controls Separately##xup-sepEx", ref config.SepEx)) update = true;
+
+                    ImGuiComponents.HelpMarker("NOTE: This feature functions by borrowing the buttons from two of your standard mouse/keyboard hotbars. Please use CrossUp's plugin configuration to select which bars to borrow.\n\nThe hotbars you choose will not be overwritten, but they will be unavailable while the feature is active.");
+
+
+                    if (ImGui.RadioButton("Show Only One Bar##xup-onlyone", config.OnlyOneEx))
+                    {
+                        config.OnlyOneEx = true;
+                        update = true;
+                    }
+
+                    if (ImGui.RadioButton("Show Both##xup-showBoth", !config.OnlyOneEx))
+                    {
+                        config.OnlyOneEx = false;
+                        update = true;
+                    }
+
+                    ImGui.EndGroup();
+                }
+                public static void LRpos(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.LRpos, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text($"{(config.OnlyOneEx ? "" : "L→R ")}Bar Position");
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker("Position is relative to the center of the Cross Hotbar.\n\nDefault: (-214, -88), which matches the Left WXHB's default location.");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-lrReset");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.LRpos = (-214, -88);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.InputInt("##xup-lrX", ref config.LRpos.x)) update = true;
+
+                    WriteIcon(ArrowsAltH, true);
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.InputInt("##xup-lrY", ref config.LRpos.y)) update = true;
+
+                    WriteIcon(ArrowsAltV, true);
+
+                    ImGui.EndGroup();
+                }
+                public static void RLpos(ref CrossUpConfig config, ref bool update)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    DrawEnabledCheckbox(ref config, CrossUpComponent.RLpos, ref update);
+
+                    ImGui.TableNextColumn();
+                    ImGui.BeginGroup();
+
+                    ImGui.Text("R→L Bar Position");
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker("Position is relative to the center of the Cross Hotbar.\n\nDefault: (214, -88), which matches the Right WXHB's default location.");
+
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-rlReset");
+                    if (ImGuiComponents.IconButton(UndoAlt))
+                    {
+                        config.RLpos = (214, -88);
+                        update = true;
+                    }
+
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.InputInt("##xup-rlX", ref config.RLpos.x)) update = true;
+
+                    WriteIcon(ArrowsAltH, true);
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(100 * Scale);
+                    if (ImGui.InputInt("##xup-rlY", ref config.RLpos.y)) update = true;
+
+                    WriteIcon(ArrowsAltV, true);
+
+                    ImGui.EndGroup();
+                }
+            }
+        }
+     
+        private static void SetUpColumns()
+        {
+            ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed, 50 * Scale);
+            ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableHeadersRow();
+        }
+        private static void WriteIcon(FontAwesomeIcon icon, bool sameLine = false)
         {
             if (sameLine) ImGui.SameLine();
             ImGui.PushFont(UiBuilder.IconFont);
             ImGui.Text($"{icon.ToIconString()}");
             ImGui.PopFont();
+        }
+        private static void DrawEnabledCheckbox(ref CrossUpConfig config, CrossUpComponent component, ref bool update)
+        {
+            var enabled = config[component];
+            if (!ImGui.Checkbox($"###xup-{component}-enabled", ref enabled)) return;
+            config[component] = enabled;
+            update = true;
         }
     }
 

--- a/HUDManager/Ui/Editor/Tabs/External/CrossUp.cs
+++ b/HUDManager/Ui/Editor/Tabs/External/CrossUp.cs
@@ -1,0 +1,655 @@
+﻿using System;
+using Dalamud.Interface;
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Components;
+using HUD_Manager.Configuration;
+using HUD_Manager.Ui;
+using ImGuiNET;
+using static HUDManager.Structs.External.CrossUpConfig;
+
+
+namespace HUDManager.Ui.Editor.Tabs;
+internal partial class ExternalElements
+{
+    public sealed class CrossUp : IExternalElement
+    {
+        public void AddButtonToList(SavedLayout layout, ref bool update)
+        {
+            var exists = layout.CrossUpConfig != null;
+            var icon = exists ? FontAwesomeIcon.TrashAlt : FontAwesomeIcon.Plus;
+            var label = $"uimanager-{(exists ? "remove" : "add")}-crossup";
+
+            if (ImGuiExt.IconButton(icon, label))
+            {
+                layout.CrossUpConfig = exists ? null : new();
+                update = true;
+            }
+
+            ImGui.SameLine();
+
+            ImGui.Text("CrossUp");
+            ImGui.SameLine();
+            ImGuiExt.HelpMarker(
+                "Install CrossUp before use. You can modify certain CrossUp settings for this layout.");
+        }
+
+        public void DrawControls(SavedLayout layout, ref bool update)
+        {
+            if (layout.CrossUpConfig == null || !ImGui.CollapsingHeader("CrossUp Settings##xup")) return;
+
+            const ImGuiTableFlags tableFlags = ImGuiTableFlags.Borders | ImGuiTableFlags.PadOuterX |
+                                               ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg;
+            const ImGuiColorEditFlags pickerFlags = ImGuiColorEditFlags.PickerMask | ImGuiColorEditFlags.DisplayHex;
+
+            if (ImGui.BeginTabBar("CrossUpTabs"))
+            {
+                if (ImGui.BeginTabItem("Cross Hotbar Layout"))
+                {
+                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
+                    {
+                        SetupColumns();
+
+                        ImGui.Indent(15f * Scale);
+                        LRSplit(ref update);
+                        Padlock(ref update);
+                        SetNumText(ref update);
+                        ChangeSetDisplay(ref update);
+                        TriggerText(ref update);
+                        UnassignedSlots(ref update);
+                        ImGui.Indent(-15f * Scale);
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Colors"))
+                {
+                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
+                    {
+                        SetupColumns();
+
+                        ImGui.Indent(15f * Scale);
+                        SelectBG(ref update);
+                        Buttons(ref update);
+                        TextColor(ref update);
+                        ImGui.Indent(-15f * Scale);
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Expanded Hold Controls"))
+                {
+                    if (ImGui.BeginTable("CrossUpTable", 2, tableFlags))
+                    {
+                        SetupColumns();
+
+                        ImGui.Indent(15f * Scale);
+                        SeparateEx(ref update);
+                        LRpos(ref update);
+                        if (!layout.CrossUpConfig.OnlyOneEx) RLpos(ref update);
+                        ImGui.Indent(-15f * Scale);
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndTabItem();
+                }
+
+                TrashButton(ref update);
+
+                ImGui.EndTabBar();
+            }
+
+            static void SetupColumns()
+            {
+                ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed, 50 * Scale);
+                ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableHeadersRow();
+            }
+
+            void DrawEnabledCheckbox(CrossUpComponent component, ref bool update1)
+            {
+                var enabled = layout.CrossUpConfig[component];
+                if (!ImGui.Checkbox($"###xup-{component}-enabled", ref enabled)) return;
+                layout.CrossUpConfig[component] = enabled;
+                update1 = true;
+            }
+
+            void LRSplit(ref bool update2)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGui.Spacing();
+                DrawEnabledCheckbox(CrossUpComponent.Split, ref update2);
+
+                ImGui.TableNextColumn();
+
+                ImGui.BeginGroup();
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, "BAR SEPARATION");
+
+                ImGui.Text("Separate Left/Right");
+                ImGui.SameLine(160f * Scale);
+                if (ImGui.Checkbox("##xup-splitOn", ref layout.CrossUpConfig.Split.on)) update2 = true;
+
+                if (layout.CrossUpConfig.Split.on)
+                {
+                    ImGui.Text("Separation Distance");
+                    ImGui.SameLine(160f * Scale);
+                    ImGui.PushID("xup-resetSplit");
+                    if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                    {
+                        layout.CrossUpConfig.Split.distance = 100;
+                        update2 = true;
+                    }
+
+                    ImGui.PopID();
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-splitDistance", ref layout.CrossUpConfig.Split.distance))
+                    {
+                        layout.CrossUpConfig.Split.distance =
+                            Math.Max(layout.CrossUpConfig.Split.distance, -142);
+                        update2 = true;
+                    }
+
+
+                    ImGui.Text("Center Point");
+                    ImGui.SameLine(160f * Scale);
+
+                    ImGui.PushID("xup-resetCenter");
+                    if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                    {
+                        layout.CrossUpConfig.Split.center = 0;
+                        update2 = true;
+                    }
+
+                    ImGui.PopID();
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(90 * Scale);
+                    if (ImGui.InputInt("##xup-centerPoint", ref layout.CrossUpConfig.Split.center))
+                        update2 = true;
+
+                    ImGuiComponents.HelpMarker(
+                        "This will override your HUD setting for the bar's horizontal position.");
+                }
+
+                ImGui.EndGroup();
+            }
+
+            void Padlock(ref bool update3)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                DrawEnabledCheckbox(CrossUpComponent.Padlock, ref update3);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("Padlock Icon");
+
+                ImGui.SameLine(160f * Scale);
+
+                ImGui.PushID("xup-resetPadlock");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Padlock = (0, 0, false);
+                    update3 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("X##xup-padlockX", ref layout.CrossUpConfig.Padlock.x)) update3 = true;
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("Y##xup-padlockY", ref layout.CrossUpConfig.Padlock.y)) update3 = true;
+
+                ImGui.SameLine();
+                if (ImGui.Checkbox("Hide##xup-hidePadlock", ref layout.CrossUpConfig.Padlock.hide))
+                    update3 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void SetNumText(ref bool update4)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                DrawEnabledCheckbox(CrossUpComponent.SetNum, ref update4);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("SET # Text");
+
+                ImGui.SameLine(160f * Scale);
+
+                ImGui.PushID("xup-resetSetNumText");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.SetNum = (0, 0, false);
+                    update4 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("X##xup-setNumTextX", ref layout.CrossUpConfig.SetNum.x)) update4 = true;
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("Y##xup-SetNumTextY", ref layout.CrossUpConfig.SetNum.y)) update4 = true;
+
+                ImGui.SameLine();
+                if (ImGui.Checkbox("Hide##xup-hideSetNumText", ref layout.CrossUpConfig.SetNum.hide))
+                    update4 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void ChangeSetDisplay(ref bool update5)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                DrawEnabledCheckbox(CrossUpComponent.ChangeSet, ref update5);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("CHANGE SET Display");
+
+                ImGui.SameLine(160f * Scale);
+
+                ImGui.PushID("xup-resetChangeSet");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.ChangeSet = (0, 0);
+                    update5 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("X##xup-changeSetX", ref layout.CrossUpConfig.ChangeSet.x)) update5 = true;
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(90 * Scale);
+                if (ImGui.InputInt("Y##xup-changeSetY", ref layout.CrossUpConfig.ChangeSet.y)) update5 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void TriggerText(ref bool update6)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                DrawEnabledCheckbox(CrossUpComponent.TriggerText, ref update6);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("Hide L/R Trigger Text");
+                ImGui.SameLine(160f * Scale);
+
+                if (ImGui.Checkbox("##xup-hideTriggerText", ref layout.CrossUpConfig.HideTriggerText))
+                    update6 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void UnassignedSlots(ref bool update7)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                DrawEnabledCheckbox(CrossUpComponent.Unassigned, ref update7);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("Hide Unassigned Slots");
+                ImGui.SameLine(160f * Scale);
+
+                if (ImGui.Checkbox("##xup-hideUnassigned", ref layout.CrossUpConfig.HideUnassigned))
+                    update7 = true;
+                ImGui.EndGroup();
+            }
+
+            void SelectBG(ref bool update8)
+            {
+                var solid = layout.CrossUpConfig.SelectBG.style == 0;
+                var frame = layout.CrossUpConfig.SelectBG.style == 1;
+                var hidden = layout.CrossUpConfig.SelectBG.style == 2;
+                var normal = layout.CrossUpConfig.SelectBG.blend == 0;
+                var dodge = layout.CrossUpConfig.SelectBG.blend == 2;
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGui.Spacing();
+                DrawEnabledCheckbox(CrossUpComponent.SelectBG, ref update8);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, "SELECTED BAR");
+
+                ImGui.Text("Backdrop Color");
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetBG");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.SelectBG.color = new(100f / 255f);
+                    update8 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-bgColor", ref layout.CrossUpConfig.SelectBG.color, pickerFlags))
+                    update8 = true;
+
+                ImGui.Text("Backdrop Style");
+                ImGui.SameLine(160f * Scale);
+                if (ImGui.RadioButton("Solid##xup-bgStyle0", solid))
+                {
+                    layout.CrossUpConfig.SelectBG.style = 0;
+                    update8 = true;
+                }
+
+                ImGui.SameLine();
+                if (ImGui.RadioButton("Frame##xup-bgStyle1", frame))
+                {
+                    layout.CrossUpConfig.SelectBG.style = 1;
+                    update8 = true;
+                }
+
+                ImGui.SameLine();
+                if (ImGui.RadioButton("Hidden##xup-bgStyle2", hidden))
+                {
+                    layout.CrossUpConfig.SelectBG.style = 2;
+                    update8 = true;
+                }
+
+                ImGui.Text("Color Blending");
+                ImGui.SameLine(160f * Scale);
+                if (ImGui.RadioButton("Normal##xup-bgBlend0", normal))
+                {
+                    layout.CrossUpConfig.SelectBG.blend = 0;
+                    update8 = true;
+                }
+
+                ImGui.SameLine();
+                if (ImGui.RadioButton("Dodge##xup-bgBlend2", dodge))
+                {
+                    layout.CrossUpConfig.SelectBG.blend = 2;
+                    update8 = true;
+                }
+
+                ImGui.EndGroup();
+            }
+
+            void Buttons(ref bool update9)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGui.Spacing();
+                DrawEnabledCheckbox(CrossUpComponent.Buttons, ref update9);
+                ImGui.TableNextColumn();
+
+                ImGui.BeginGroup();
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, "BUTTONS");
+
+
+                ImGui.Text("Button Glow");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetButtonGlow");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Buttons.glow = new(1f);
+                    update9 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-buttonGlow", ref layout.CrossUpConfig.Buttons.glow, pickerFlags))
+                    update9 = true;
+
+
+                ImGui.Text("Button Pulse");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetButtonPulse");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Buttons.pulse = new(1f);
+                    update9 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-ButtonPulse", ref layout.CrossUpConfig.Buttons.pulse, pickerFlags))
+                    update9 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void TextColor(ref bool update10)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGui.Spacing();
+                DrawEnabledCheckbox(CrossUpComponent.Text, ref update10);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, "TEXT & BORDERS");
+
+
+                ImGui.Text("Text Color");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetTextColor");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Text.color = new(1f);
+                    update10 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-textColor", ref layout.CrossUpConfig.Text.color, pickerFlags))
+                    update10 = true;
+
+
+                ImGui.Text("Text Glow");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetTextGlow");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Text.glow = new(0.616f, 0.514f, 0.357f);
+                    update10 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-textGlow", ref layout.CrossUpConfig.Text.glow, pickerFlags))
+                    update10 = true;
+
+
+                ImGui.Text("Border Color");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-resetBorder");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.Text.border = new(1f);
+                    update10 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.ColorEdit3("##xup-border", ref layout.CrossUpConfig.Text.border, pickerFlags))
+                    update10 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void SeparateEx(ref bool update11)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGui.Spacing();
+                DrawEnabledCheckbox(CrossUpComponent.SepEx, ref update11);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, "EXPANDED HOLD CONTROLS");
+                if (ImGui.Checkbox("Display Expanded Hold Controls Separately##xup-sepEx",
+                        ref layout.CrossUpConfig.SepEx)) update11 = true;
+
+                ImGuiComponents.HelpMarker(
+                    "NOTE: This feature functions by borrowing the buttons from two of your standard mouse/keyboard hotbars. Please use CrossUp's plugin configuration to select which bars to borrow.\n\nThe hotbars you choose will not be overwritten, but they will be unavailable while the feature is active.");
+
+
+                if (ImGui.RadioButton("Show Only One Bar##xup-onlyone", layout.CrossUpConfig.OnlyOneEx))
+                {
+                    layout.CrossUpConfig.OnlyOneEx = true;
+                    update11 = true;
+                }
+
+                ImGui.SameLine();
+                if (ImGui.RadioButton("Show Both##xup-showBoth", !layout.CrossUpConfig.OnlyOneEx))
+                {
+                    layout.CrossUpConfig.OnlyOneEx = false;
+                    update11 = true;
+                }
+
+
+                ImGui.EndGroup();
+            }
+
+            void LRpos(ref bool update12)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                DrawEnabledCheckbox(CrossUpComponent.LRpos, ref update12);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text($"{(layout.CrossUpConfig.OnlyOneEx ? "" : "L→R ")}Bar Position");
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    "Position is relative to the center of the Cross Hotbar.\n\nDefault: (-214, -88), which matches the Left WXHB's default location.");
+
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-lrReset");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.LRpos = (-214, -88);
+                    update12 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.InputInt("X##xup-lrX", ref layout.CrossUpConfig.LRpos.x)) update12 = true;
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.InputInt("Y##xup-lrY", ref layout.CrossUpConfig.LRpos.y)) update12 = true;
+
+                ImGui.EndGroup();
+            }
+
+            void RLpos(ref bool update13)
+            {
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                DrawEnabledCheckbox(CrossUpComponent.RLpos, ref update13);
+
+                ImGui.TableNextColumn();
+                ImGui.BeginGroup();
+
+                ImGui.Text("R→L Bar Position");
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    "Position is relative to the center of the Cross Hotbar.\n\nDefault: (214, -88), which matches the Right WXHB's default location.");
+
+                ImGui.SameLine(160f * Scale);
+                ImGui.PushID("xup-rlReset");
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.UndoAlt))
+                {
+                    layout.CrossUpConfig.RLpos = (214, -88);
+                    update13 = true;
+                }
+
+                ImGui.PopID();
+
+                ImGui.SameLine();
+
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.InputInt("X##xup-rlX", ref layout.CrossUpConfig.RLpos.x)) update13 = true;
+
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100 * Scale);
+                if (ImGui.InputInt("Y##xup-rlY", ref layout.CrossUpConfig.RLpos.y)) update13 = true;
+
+
+                ImGui.EndGroup();
+            }
+
+            void TrashButton(ref bool update14)
+            {
+                ImGui.SameLine(ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 1.5f * Scale);
+                if (ImGuiExt.IconButton(FontAwesomeIcon.TrashAlt, "xup-overlay-remove"))
+                {
+                    layout.CrossUpConfig = null;
+                    update14 = true;
+                }
+
+                ImGuiExt.HoverTooltip("Remove CrossUp settings from this layout");
+            }
+        }
+
+    }
+
+    private static float Scale => ImGuiHelpers.GlobalScale;
+}

--- a/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
+++ b/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
@@ -1,10 +1,7 @@
-﻿using Dalamud.Interface;
-using HUD_Manager;
+﻿using HUD_Manager;
 using HUD_Manager.Configuration;
 using HUD_Manager.Ui;
 using ImGuiNET;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace HUDManager.Ui.Editor.Tabs
@@ -18,24 +15,25 @@ namespace HUDManager.Ui.Editor.Tabs
         {
             this.Plugin = plugin;
             this.Ui = ui;
+
+            Elements = new IExternalElement[] {
+                new Browsingway(this.Plugin), 
+                new CrossUp(this.Plugin)
+            };
         }
 
         public interface IExternalElement
         {
-            public bool Available(Plugin plugin);
+            public bool Available();
             public void AddButtonToList(SavedLayout layout, ref bool update, bool available);
             public void DrawControls(SavedLayout layout, ref bool update);
         }
 
-        private readonly IExternalElement[] Elements =
-        {
-            new Browsingway(), 
-            new CrossUp()
-        };
+        private readonly IExternalElement[] Elements;
 
         internal void Draw(SavedLayout layout, ref bool update)
         {
-            foreach (var elem in Elements) elem.AddButtonToList(layout, ref update, elem.Available(this.Plugin));
+            foreach (var elem in Elements) elem.AddButtonToList(layout, ref update, elem.Available());
 
             if (!ImGui.BeginChild("uimanager-overlay-edit", new Vector2(0, 0), true)) return;
             

--- a/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
+++ b/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
@@ -22,7 +22,8 @@ namespace HUDManager.Ui.Editor.Tabs
 
         public interface IExternalElement
         {
-            public void AddButtonToList(SavedLayout layout, ref bool update);
+            public bool Available(Plugin plugin);
+            public void AddButtonToList(SavedLayout layout, ref bool update, bool available);
             public void DrawControls(SavedLayout layout, ref bool update);
         }
 
@@ -34,11 +35,11 @@ namespace HUDManager.Ui.Editor.Tabs
 
         internal void Draw(SavedLayout layout, ref bool update)
         {
-            foreach (var e in Elements) e.AddButtonToList(layout, ref update);
+            foreach (var elem in Elements) elem.AddButtonToList(layout, ref update, elem.Available(this.Plugin));
 
             if (!ImGui.BeginChild("uimanager-overlay-edit", new Vector2(0, 0), true)) return;
             
-            foreach (var e in Elements) e.DrawControls(layout, ref update);
+            foreach (var elem in Elements) elem.DrawControls(layout, ref update);
 
             if (update)
             {

--- a/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
+++ b/HUDManager/Ui/Editor/Tabs/ExternalElements.cs
@@ -2,7 +2,6 @@
 using HUD_Manager;
 using HUD_Manager.Configuration;
 using HUD_Manager.Ui;
-using HUDManager.Structs.External;
 using ImGuiNET;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,114 +9,41 @@ using System.Numerics;
 
 namespace HUDManager.Ui.Editor.Tabs
 {
-    internal class ExternalElements
+    internal partial class ExternalElements
     {
-        private Plugin plugin { get; init; }
+        private Plugin Plugin { get; }
+        private Interface Ui { get; }
 
-        public ExternalElements(Plugin plugin)
+        public ExternalElements(Plugin plugin, Interface ui)
         {
-            this.plugin = plugin;
+            this.Plugin = plugin;
+            this.Ui = ui;
         }
+
+        public interface IExternalElement
+        {
+            public void AddButtonToList(SavedLayout layout, ref bool update);
+            public void DrawControls(SavedLayout layout, ref bool update);
+        }
+
+        private readonly IExternalElement[] Elements =
+        {
+            new Browsingway(), 
+            new CrossUp()
+        };
 
         internal void Draw(SavedLayout layout, ref bool update)
         {
-            if (ImGuiExt.IconButton(FontAwesomeIcon.Plus, "uimanager-add-browsingway")) {
-                layout.BrowsingwayOverlays.Add(new BrowsingwayOverlay());
-            }
+            foreach (var e in Elements) e.AddButtonToList(layout, ref update);
 
-            ImGui.SameLine();
-            ImGui.Text("Browsingway");
-            ImGui.SameLine();
-            ImGuiExt.HelpMarker("Install the Browsingway plugin before use. You can set up changes to Browsingway overlays using this menu.");
+            if (!ImGui.BeginChild("uimanager-overlay-edit", new Vector2(0, 0), true)) return;
+            
+            foreach (var e in Elements) e.DrawControls(layout, ref update);
 
-            if (!ImGui.BeginChild("uimanager-overlay-edit", new Vector2(0, 0), true)) {
-                return;
-            }
-
-            List<BrowsingwayOverlay> toRemove = new();
-
-            foreach (var (overlay, i) in layout.BrowsingwayOverlays.Select((overlay, i) => (overlay, i))) {
-
-                if (!ImGui.CollapsingHeader($"{overlay.CommandName}###bw-overlay-{i}")) {
-                    continue;
-                }
-
-                const ImGuiTableFlags flags = ImGuiTableFlags.BordersInner
-                                              | ImGuiTableFlags.PadOuterX
-                                              | ImGuiTableFlags.SizingFixedFit
-                                              | ImGuiTableFlags.RowBg;
-                if (!ImGui.BeginTable($"bw-overlay-table-{i}", 3, flags)) {
-                    continue;
-                }
-
-                ImGui.TableSetupColumn("Enabled");
-                ImGui.TableSetupColumn("Setting");
-                ImGui.TableSetupColumn("Control", ImGuiTableColumnFlags.WidthStretch);
-                ImGui.TableHeadersRow();
-
-                ImGui.SameLine(ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 3);
-                if (ImGuiExt.IconButton(FontAwesomeIcon.TrashAlt, $"bw-overlay-remove-{i}")) {
-                    toRemove.Add(overlay);
-                    update = true;
-                }
-
-                ImGuiExt.HoverTooltip("Remove this element from this layout");
-
-                ImGui.TableNextRow();
-
-                static void DrawSettingName(string name)
-                {
-                    ImGui.TextUnformatted(name);
-                    ImGui.TableNextColumn();
-                }
-
-                void DrawEnabledCheckbox(BrowsingwayOverlay.BrowsingwayOverlayComponent component, ref bool update, bool nextCol = true)
-                {
-                    if (nextCol) {
-                        ImGui.TableNextColumn();
-                    }
-
-                    var enabled = overlay[component];
-                    if (ImGui.Checkbox($"###bw-{component}-enabled-{i}", ref enabled)) {
-                        overlay[component] = enabled;
-                        update = true;
-                    }
-
-                    ImGui.TableNextColumn();
-                }
-
-                // Name setting
-                ImGui.TableSetColumnIndex(1);
-                DrawSettingName("Name");
-                if (ImGui.InputText($"###bw-name-{i}", ref overlay.CommandName, 128)) {
-                    update = true;
-                }
-
-                ImGui.TableNextRow();
-                ImGui.TableSetColumnIndex(0);
-
-                void DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent component, string settingName, ref bool setting, ref bool update)
-                {
-                    ImGui.TableSetColumnIndex(0);
-
-                    DrawEnabledCheckbox(component, ref update, false);
-                    DrawSettingName(settingName);
-                    if (ImGui.Checkbox($"###bw-{settingName}-{i}", ref setting)) {
-                        update = true;
-                    }
-                    ImGui.TableNextRow();
-                }
-
-                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Hidden, "Hidden", ref overlay.Hidden, ref update);
-                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Locked, "Locked", ref overlay.Locked, ref update);
-                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Typethrough, "Typethrough", ref overlay.Typethrough, ref update);
-                DrawSettingRow(BrowsingwayOverlay.BrowsingwayOverlayComponent.Clickthrough, "Clickthrough", ref overlay.Clickthrough, ref update);
-
-                ImGui.EndTable();
-            }
-
-            foreach (var overlay in toRemove) {
-                layout.BrowsingwayOverlays.Remove(overlay);
+            if (update)
+            {
+                this.Plugin.Hud.WriteEffectiveLayout(this.Plugin.Config.StagingSlot, this.Ui.SelectedLayout);
+                this.Plugin.Hud.SelectSlot(this.Plugin.Config.StagingSlot, true);
             }
 
             ImGui.EndChild();

--- a/HUDManager/Util.cs
+++ b/HUDManager/Util.cs
@@ -41,6 +41,16 @@ namespace HUD_Manager
             }
         }
 
+        public static bool FullScreen() // treats Borderless as Full Screen
+        {
+            unsafe
+            {
+                var configModule = ConfigModule.Instance();
+                var option = configModule->GetIntValue((short)ConfigOption.ScreenMode);
+                return option > 0;
+            }
+        }
+
         public readonly static Dictionary<uint, string> JobIdToEnglishAbbreviation = new Dictionary<uint, string>()
         {
             [0] = "ADV",


### PR DESCRIPTION
Sorry for leaving this so long after I first brought it up! I'm PR'ing my changes here, but I don't know how they'll mesh with whatever updates the overall plugin needs for 6.4. Implement/revise at your discretion, of course.

The biggest area I tinkered with was modularizing the external elements tab, so that the CrossUp and Browsingway content each have their own files (and an interface type for writing them to the tab). Hopefully keeps things tidy, and might make it easier for other plugins to create modules too.

Cheers!