### PR TITLE
Fixes for 6.4

### DIFF
--- a/HUDManager/HUDManager.csproj
+++ b/HUDManager/HUDManager.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0-windows</TargetFramework>
-        <Version>2.5.13.0</Version>
+        <Version>2.5.13.1</Version>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -24,8 +24,8 @@ namespace HUD_Manager
         // Each element is 32 bytes in ADDON.DAT, but they're 36 bytes when loaded into memory.
         private const int LayoutSize = InMemoryLayoutElements * 36;
 
-        // Updated 6.1
-        private const int SlotOffset = 0x6378;
+        // Updated 6.4
+        private const int SlotOffset = 0x6408;
 
         private delegate IntPtr GetFilePointerDelegate(byte index);
 

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Dalamud.Game.ClientState.Objects.Enums;
 
 // TODO: Zone swaps?
 
@@ -44,27 +45,6 @@ namespace HUD_Manager
         private IntPtr InFateAreaPtr = IntPtr.Zero;
 
         private long LastUpdateTime = 0;
-
-        public static byte GetStatus(GameObject actor)
-        {
-            // Updated: 6.3
-            const int offset = 0x1B1B;
-            return Marshal.ReadByte(actor.Address + offset);
-        }
-
-        internal static byte GetOnlineStatus(GameObject actor)
-        {
-            // Updated: 6.3
-            const int offset = 0x1B02;
-            return Marshal.ReadByte(actor.Address + offset);
-        }
-
-        internal static byte GetBardThing(GameObject actor)
-        {
-            // Updated: 6.3
-            const int offset = 0x1B00;
-            return Marshal.ReadByte(actor.Address + offset);
-        }
 
         public Statuses(Plugin plugin)
         {
@@ -443,11 +423,11 @@ namespace HUD_Manager
 
             switch (status) {
                 case Status.WeaponDrawn:
-                    return (Statuses.GetStatus(player!) & 4) > 0;
+                    return (player!.StatusFlags & StatusFlags.WeaponOut) != 0;
                 case Status.Roleplaying:
-                    return Statuses.GetOnlineStatus(player!) == 22;
+                    return player!.OnlineStatus.Id == 22;
                 case Status.PlayingMusic:
-                    return Statuses.GetBardThing(player!) == 16;
+                    return plugin.Condition[ConditionFlag.Performing];
                 case Status.InPvp:
                     return plugin.Statuses.InPvpZone;
                 case Status.InDialogue:


### PR DESCRIPTION
Hello. I've tried to fix some things that were broken by 6.4. Most importantly the `SlotOffset` needed to be updated, which was causing most things to not work at all.

I also noticed some conditions were using offsets which needed updating, and in the process tried to use alternatives where possible. I tested `WeaponDrawn` and `Roelplaying` which seemed to work fine, but sadly I don't have a Bard to test `PlayingMusic`.

There might be other issues which I didn't find, but these changes were enough to get the plugin working for me.