### PR TITLE
Fix additional 6.4 issues

### DIFF
--- a/HUDManager/HUDManager.csproj
+++ b/HUDManager/HUDManager.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0-windows</TargetFramework>
-        <Version>2.5.13.1</Version>
+        <Version>2.5.13.2</Version>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/HUDManager/Structs/ElementKind.cs
+++ b/HUDManager/Structs/ElementKind.cs
@@ -100,7 +100,8 @@ namespace HUD_Manager.Structs
         CrystallineConflictBattleLog = 4081580003,
         CrystallineConflictMap = 3282875858,
         CrystallineConflictEnemyInfo = 3805361436,
-        CrystallineConflictProgressGauge = 812941873
+        CrystallineConflictProgressGauge = 812941873,
+        FrontlineScoreInfo = 758283662
     }
 
     public static class ElementKindExt
@@ -235,6 +236,7 @@ namespace HUD_Manager.Structs
                 ElementKind.CrystallineConflictEnemyInfo => 95,
                 ElementKind.CrystallineConflictBattleLog => 96,
                 ElementKind.CrystallineConflictMap => 97,
+                ElementKind.FrontlineScoreInfo => 98,
                 _ => -1
             };
         }

--- a/HUDManager/Swapper.cs
+++ b/HUDManager/Swapper.cs
@@ -51,6 +51,10 @@ namespace HUD_Manager
                 return;
             }
 
+            if (Util.IsCharacterConfigOpen()) {
+                return;
+            }
+
             var updated = this.Plugin.Statuses.Update()
                 || this.Plugin.Keybinder.UpdateKeyState()
                 || this.Plugin.Statuses.CustomConditionStatus.IsUpdated();

--- a/HUDManager/Ui/Editor/LayoutEditor.cs
+++ b/HUDManager/Ui/Editor/LayoutEditor.cs
@@ -57,8 +57,7 @@ namespace HUD_Manager.Ui.Editor
 
             var update = false;
 
-            var charConfig = this.Plugin.GameGui.GetAtkUnitByName("ConfigCharacter", 1);
-            if (charConfig != null) {
+            if (Util.IsCharacterConfigOpen()) {
                 ImGui.TextUnformatted("Please close the Character Configuration window before continuing.");
                 goto EndTabItem;
             }

--- a/HUDManager/Util.cs
+++ b/HUDManager/Util.cs
@@ -5,6 +5,7 @@ using Lumina.Excel.GeneratedSheets;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 namespace HUD_Manager
 {
@@ -38,6 +39,15 @@ namespace HUD_Manager
                 var configModule = ConfigModule.Instance();
                 var option = configModule->GetIntValue((short)ConfigOption.PadMode);
                 return option > 0;
+            }
+        }
+
+        public static bool IsCharacterConfigOpen()
+        {
+            unsafe {
+                var agent = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->GetUiModule()->GetAgentModule()->
+                    GetAgentByInternalId(AgentId.ConfigCharacter);
+                return agent->IsAgentActive();
             }
         }
 


### PR DESCRIPTION
This PR fixes two issues:

1. Adds support for the new Frontline Score Info HUD panel, new in 6.4.

2. Attempts to prevent an issue where calls to the `setHudLayout` hooked function while the Character Configuration window is open would reset the active HUD slot to slot 1.

Regarding point 2, this seems to be an issue with native code not expecting that function to be called while said window is open, and I wasn't able to figure out a fix. Indeed this is not possible in an unmodified game, and game even blocks the /hudlayout macro commands when Character Config is open. So preventing the addon from trying to do this is quite possibly the correct thing to do.

In order to do this I just made it so that swaps are blocked entirely if the Character Config window is open during a `OnFrameworkUpdate`. I'm not sure if this is actually a 6.4 bug as I occasionally experienced unexpected HUD slot swaps before in rare cases and this may have been the cause.

Apologies for the PR with unrelated multiple changes, let me know if you would prefer it split per fix or have any other concerns.

Thanks.