### PR TITLE
Various bug fixes, performance improvements, and so on

### DIFF
--- a/HUDManager/HUDManager.csproj
+++ b/HUDManager/HUDManager.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0-windows</TargetFramework>
-        <Version>2.5.14.0</Version>
+        <Version>2.5.14.1</Version>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -162,6 +162,11 @@ namespace HUD_Manager
                 if (!dict.TryGetValue(slotLayout.elements[i].id, out var element))
                     continue;
 
+                if (element.Id == ElementKind.Minimap && reloadIfNecessary) {
+                    // Don't load minimap zoom/rotation from HUD settings but use current UI state instead
+                    element.Options = slotLayout.elements[i].options;
+                }
+
                 // just replace the struct if all options are enabled
                 if (element.Enabled == Element.AllEnabled) {
                     slotLayout.elements[i] = new RawElement(element);

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -33,7 +33,6 @@ namespace HUD_Manager
 
         private readonly GetFilePointerDelegate? _getFilePointer;
         private readonly SetHudLayoutDelegate? _setHudLayout;
-        private Hook<SetHudLayoutDelegate> _setHudLayoutHook;
 
         private List<(string name, ElementKind kind, Element e)> currentJobGauges = new();
 
@@ -52,10 +51,6 @@ namespace HUD_Manager
             if (setHudLayoutPtr != IntPtr.Zero) {
                 this._setHudLayout = Marshal.GetDelegateForFunctionPointer<SetHudLayoutDelegate>(setHudLayoutPtr);
             }
-
-            // Set up the hook to refresh the pet hotbar when HUD is changed.
-            this._setHudLayoutHook = new Hook<SetHudLayoutDelegate>(setHudLayoutPtr, this.SetHudLayoutDetour);
-            this._setHudLayoutHook.Enable();
 
             plugin.Framework.Update += RunRecurringTasks;
         }
@@ -355,17 +350,8 @@ namespace HUD_Manager
             }
         }
 
-        private uint SetHudLayoutDetour(IntPtr filePtr, uint hudLayout, byte unk0, byte unk1)
-        {
-            var res = this._setHudLayoutHook.Original(filePtr, hudLayout, unk0, unk1);
-            this.Plugin.PetHotbar.ResetPetHotbar();
-            return res;
-        }
-
         public void Dispose()
         {
-            this._setHudLayoutHook.Disable();
-            this._setHudLayoutHook.Dispose();
             this.Plugin.Framework.Update -= RunRecurringTasks;
         }
     }

--- a/HUDManager/Plugin.cs
+++ b/HUDManager/Plugin.cs
@@ -113,7 +113,6 @@ namespace HUD_Manager
             this.Commands.Dispose();
             this.Ui.Dispose();
             this.Swapper.Dispose();
-            this.Statuses.Dispose();
             this.PetHotbar.Dispose();
             this.Hud.Dispose();
         }

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -30,7 +30,8 @@ namespace HUD_Manager
         private Plugin Plugin { get; }
 
         public readonly Dictionary<Status, bool> Condition = new();
-        public ClassJob? Job { get; private set; }
+        private readonly IEnumerable<Status> StatusTypes = Enum.GetValues(typeof(Status)).Cast<Status>();
+        private uint LastJobId = uint.MaxValue;
 
         public (HudConditionMatch? activeLayout, List<HudConditionMatch> layeredLayouts) ResultantLayout = (null, new());
         private Dictionary<HudConditionMatch, float> ConditionHoldTimers = new();
@@ -86,14 +87,14 @@ namespace HUD_Manager
 
             var anyChanged = false;
 
-            var currentJob = this.Plugin.DataManager.GetExcelSheet<ClassJob>()!.GetRow(player.ClassJob.Id);
-            if (this.Job != null && this.Job != currentJob) {
+            var currentJobId = player.ClassJob.Id;
+            if (this.LastJobId != currentJobId) {
                 anyChanged = true;
             }
 
-            this.Job = currentJob;
+            this.LastJobId = currentJobId;
 
-            foreach (Status status in Enum.GetValues(typeof(Status))) {
+            foreach (Status status in StatusTypes) {
                 var old = this.Condition.ContainsKey(status) && this.Condition[status];
                 this.Condition[status] = status.Active(this.Plugin, player);
                 anyChanged |= old != this.Condition[status];

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -20,6 +20,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Dalamud.Game.ClientState.Objects.Enums;
+using FFXIVClientStructs.FFXIV.Client.Game;
 
 // TODO: Zone swaps?
 
@@ -165,14 +166,12 @@ namespace HUD_Manager
             //this.Plugin.Hud.SelectSlot(this.Plugin.Config.StagingSlot, true);
         }
 
-        public bool IsInFate(Character player)
+        public bool IsInFate()
         {
-            unsafe {
-                return (Marshal.ReadByte(InFateAreaPtr) == 1);
-            }
+            return Marshal.ReadByte(InFateAreaPtr) == 1;
         }
 
-        public bool IsLevelSynced(Character player)
+        public bool IsLevelSynced()
         {
             unsafe {
                 var uiPlayerState = UIState.Instance()->PlayerState;
@@ -182,36 +181,7 @@ namespace HUD_Manager
 
         public bool IsInSanctuary()
         {
-            if (SanctuaryDetectionFailed)
-                return false;
-
-            var expBar = Plugin.GameGui.GetAtkUnitByName("_Exp", 1);
-            if (!expBar.HasValue) {
-                PluginLog.Error("Unable to find EXP bar element for sanctuary detection");
-                SanctuaryDetectionFailed = true;
-                return false;
-            }
-
-            const int expBarAtkMoonIconIndex = 3;
-            unsafe {
-                // TODO Find a real memory address where this is stored instead of descending into UI elements LMAO
-                int i = 0;
-                var node = expBar.Value.RootNode;
-
-                if (node->ChildCount < expBarAtkMoonIconIndex) {
-                    PluginLog.Error("Not enough child nodes in EXP bar element for sanctuary detection");
-                    SanctuaryDetectionFailed = true;
-                    return false;
-                }
-
-                node = node->ChildNode;
-                while (i < expBarAtkMoonIconIndex) {
-                    node = node->PrevSiblingNode;
-                    i++;
-                }
-
-                return node->IsVisible;
-            }
+            return GameMain.IsInSanctuary();
         }
 
         public bool IsChatFocused()
@@ -442,9 +412,9 @@ namespace HUD_Manager
                         | plugin.Condition[ConditionFlag.OccupiedInQuestEvent]
                         | plugin.Condition[ConditionFlag.OccupiedSummoningBell];
                 case Status.InFate:
-                    return plugin.Statuses.IsInFate(player!);
+                    return plugin.Statuses.IsInFate();
                 case Status.InFateLevelSynced:
-                    return plugin.Statuses.IsInFate(player!) && plugin.Statuses.IsLevelSynced(player!);
+                    return plugin.Statuses.IsInFate() && plugin.Statuses.IsLevelSynced();
                 case Status.InSanctuary:
                     return plugin.Statuses.IsInSanctuary();
                 case Status.ChatFocused:
@@ -465,10 +435,7 @@ namespace HUD_Manager
         private static readonly ReadOnlyCollection<Status> RequiresPlayer = new(new List<Status>()
         {
             Status.WeaponDrawn,
-            Status.Roleplaying,
-            Status.PlayingMusic,
-            Status.InFate,
-            Status.InFateLevelSynced
+            Status.Roleplaying
         });
     }
 }

--- a/HUDManager/Structs/RawElement.cs
+++ b/HUDManager/Structs/RawElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace HUD_Manager.Structs
 {
@@ -73,6 +74,22 @@ namespace HUD_Manager.Structs
             if (element[ElementComponent.Options]) {
                 this.options = element.Options;
             }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(id)}: {id}, " +
+                   $"{nameof(x)}: {x}, " +
+                   $"{nameof(y)}: {y}, " +
+                   $"{nameof(scale)}: {scale}, " +
+                   $"{nameof(options)}: {BitConverter.ToString(options)}, " +
+                   $"{nameof(width)}: {width}, " +
+                   $"{nameof(height)}: {height}, " +
+                   $"{nameof(measuredFrom)}: {measuredFrom}, " +
+                   $"{nameof(visibility)}: {visibility}, " +
+                   $"{nameof(unknown6)}: 0x{unknown6:X}, " +
+                   $"{nameof(opacity)}: 0x{opacity:X}, " +
+                   $"{nameof(unknown8)}: {BitConverter.ToString(unknown8)}";
         }
     }
 }

--- a/HUDManager/Swapper.cs
+++ b/HUDManager/Swapper.cs
@@ -4,6 +4,7 @@ using Dalamud.Logging;
 using HUDManager.Configuration;
 using System;
 using System.Collections.Generic;
+using Dalamud.Game.ClientState.Conditions;
 
 namespace HUD_Manager
 {
@@ -51,7 +52,15 @@ namespace HUD_Manager
                 return;
             }
 
+            // Skipping due to bugs caused by HUD swaps while Character Config is open
             if (Util.IsCharacterConfigOpen()) {
+                return;
+            }
+
+            // Skipping due to HUD swaps in cutscenes causing main menu to become visible
+            if (Plugin.Condition[ConditionFlag.OccupiedInCutSceneEvent]
+                || Plugin.Condition[ConditionFlag.WatchingCutscene78]
+                || Plugin.Condition[ConditionFlag.BoundByDuty95]) {
                 return;
             }
 

--- a/HUDManager/Ui/Debug.cs
+++ b/HUDManager/Ui/Debug.cs
@@ -134,7 +134,7 @@ namespace HUD_Manager.Ui
 
             if (ImGui.Button("FATE Status")) {
                 ////PluginLog.Log($"{this.Plugin.Statuses.IsInFate(this.Plugin.ClientState.LocalPlayer)}");
-                PluginLog.Log($"{this.Plugin.Statuses.IsLevelSynced(this.Plugin.ClientState.LocalPlayer)}");
+                PluginLog.Log($"{this.Plugin.Statuses.IsLevelSynced()}");
 
             }
 


### PR DESCRIPTION
By commit:

1. [Reduce Swapper framework update time](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/697fef9ad4b3d46dd29f6f642038aef1088b3338) - Decrease the framework update time significantly (in my case, reducing frame time from roughly 0.0270ms to 0.0080ms) by making some minor changes to `Statuses.Update` to avoid calling slow functions.

2. [Simplify some condition logic](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/d999e2d50e6ea7b4c6d8f1e834a7f7cf086822b1) - Replace custom sanctuary check with `GameMain.IsInSanctuary`, and remove some Player dependencies which were no longer needed.

3. [Simplify PvP status](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/57a11949a32878f423e885f349428dfbd5d53229) - Replace custom PvP logic with `ClientState.IsPvP`. Probably fixes #49.

4. [Work around new PvP pet bar bug and remove fix for old pet issue](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/7fa555c0de4403863358833bf55fbc563fb71551) - Fixes #65 (and probably fixes #38) and removes old workaround code for the previous pet hotbar bug which has since been fixed in the game itself. Seems like when fixing this old pet-bar-swap bug they reintroduced a new one which only happens in PvP. This was quite tricky to figure out but I was able to create a workaround by detecting the (failed, due to the bug) reset and doing a set-and-reset in subsequent frames. It's actually similar to the last workaround, but rather than trying to restore a pet bar which was lost, we're trying to get rid of a pet bar which won't go away. Only applies to PvP and only when using the option to overlay pet bars over hotbar 1.

5. [Fix minimap zoom and rotation from being reset on HUD swap](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/abf809318af934b202d3ce3fef9b9bfedf8a7e63) - Fixes #71 by no longer overriding minimap zoom/rotation based on stored HUD settings, but instead allowing current zoom/rotation state to persist after a HUD swap.

6. [Disable swaps during cutscenes to stop main menu reappearing](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/b333a58c12b3e4e701e22fa449be8a2cc259670c) - Fixes #54 (main menu reappears during cutscene/UI hidden event when HUD swap occurs) by blocking swaps during cutscenes.

7. [Bump version to 2.5.14.1](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/9b3537b7a2bb55f9c614b62486e9015e5947e2d6) - Version bump.

Thank you!