### PR TITLE
Numerous fixes

### DIFF
--- a/HUDManager/HUDManager.csproj
+++ b/HUDManager/HUDManager.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0-windows</TargetFramework>
-        <Version>2.5.15.0</Version>
+        <Version>2.5.16.0</Version>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -52,7 +52,8 @@ namespace HUD_Manager
                 this._setHudLayout = Marshal.GetDelegateForFunctionPointer<SetHudLayoutDelegate>(setHudLayoutPtr);
             }
 
-            plugin.Framework.Update += RunRecurringTasks;
+            // Removed since this is not actually running anything currently.
+            // plugin.Framework.Update += RunRecurringTasks;
         }
 
         public IntPtr GetFilePointer(byte index)

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using HUD_Manager.Structs.Options;
 
 namespace HUD_Manager
 {
@@ -163,9 +164,16 @@ namespace HUD_Manager
                 if (!dict.TryGetValue(slotLayout.elements[i].id, out var element))
                     continue;
 
-                if (element.Id == ElementKind.Minimap && reloadIfNecessary) {
-                    // Don't load minimap zoom/rotation from HUD settings but use current UI state instead
-                    element.Options = slotLayout.elements[i].options;
+                if (reloadIfNecessary) {
+                    if (element.Id is ElementKind.Minimap) {
+                        // Minimap: Don't load zoom/rotation from HUD settings but use current UI state instead
+                        element.Options = slotLayout.elements[i].options;
+                    }
+
+                    if (element.Id is ElementKind.Hotbar1 && reloadIfNecessary) {
+                        // Hotbar1: Keep cycling state
+                        element.Options![0] = slotLayout.elements[i].options![0];
+                    }
                 }
 
                 // just replace the struct if all options are enabled

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -18,8 +18,8 @@ namespace HUD_Manager
 {
     public class Hud : IDisposable
     {
-        // Updated 6.11a
-        public const int InMemoryLayoutElements = 98;
+        // Updated 6.45
+        public const int InMemoryLayoutElements = 99;
 
         // Updated 5.45
         // Each element is 32 bytes in ADDON.DAT, but they're 36 bytes when loaded into memory.

--- a/HUDManager/Hud.cs
+++ b/HUDManager/Hud.cs
@@ -349,7 +349,7 @@ namespace HUD_Manager
                 if (unit is null)
                     return;
 
-                var visibilityMask = Util.GamepadModeActive() ? VisibilityFlags.Gamepad : VisibilityFlags.Keyboard;
+                var visibilityMask = Util.GamepadModeActive(Plugin) ? VisibilityFlags.Gamepad : VisibilityFlags.Keyboard;
                 if ((element.Visibility & visibilityMask) > 0) {
                     // Reveal element.
                     if (unit->UldManager.NodeListCount == 0)

--- a/HUDManager/PetHotbar.cs
+++ b/HUDManager/PetHotbar.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Dalamud.Game;
-using Dalamud.Game.Config;
 using Dalamud.Hooking;
 using Dalamud.Logging;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using ClientFramework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework;
 
 namespace HUD_Manager;
@@ -84,13 +82,7 @@ public class PetHotbar : IDisposable
         if (plugin.ClientState.IsPvP && fixStage == FixingPvpPetBar.Off) {
             var hotbarPetType = unchecked((uint)Marshal.ReadInt32(hotbarPetTypePtr));
             if (hotbarPetType > 0) {
-                bool isPetOverlayEnabled;
-                unsafe {
-                    var configModule = ConfigModule.Instance();
-                    isPetOverlayEnabled = configModule->GetIntValue((short)ConfigOption.ExHotbarChangeHotbar1) > 0;
-                }
-
-                if (isPetOverlayEnabled) {
+                if (plugin.GameConfig.UiConfig.TryGet("ExHotbarChangeHotbar1", out bool isPetOverlayEnabled) && isPetOverlayEnabled) {
                     PluginLog.Debug("PetHotbarFix F0: Detected potentially broken pet hotbar overlay. Fixing...");
                     fixStage = FixingPvpPetBar.Setup;
                     fixPetType = hotbarPetType;

--- a/HUDManager/Plugin.cs
+++ b/HUDManager/Plugin.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Dalamud.Game.Config;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -36,6 +37,7 @@ namespace HUD_Manager
         public GameGui GameGui { get; init; }
         public ChatGui ChatGui { get; init; }
         public KeyState KeyState { get; init; }
+        public GameConfig GameConfig { get; init; }
 
         public Swapper Swapper { get; set; } = null!;
         private Commands Commands { get; set; } = null!;
@@ -61,7 +63,8 @@ namespace HUD_Manager
             [RequiredVersion("1.0")] SigScanner sigScanner,
             [RequiredVersion("1.0")] GameGui gameGui,
             [RequiredVersion("1.0")] ChatGui chatGui,
-            [RequiredVersion("1.0")] KeyState keyState)
+            [RequiredVersion("1.0")] KeyState keyState,
+            [RequiredVersion("1.0")] GameConfig gameConfig)
         {
             this.Interface = pluginInterface;
             this.CommandManager = commandManager;
@@ -73,6 +76,7 @@ namespace HUD_Manager
             this.GameGui = gameGui;
             this.ChatGui = chatGui;
             this.KeyState = keyState;
+            this.GameConfig = gameConfig;
 
             ClassJobCategoryIdExtensions.Initialize(this);
             ElementKindExt.Initialize(this.DataManager);

--- a/HUDManager/Plugin.cs
+++ b/HUDManager/Plugin.cs
@@ -49,6 +49,8 @@ namespace HUD_Manager
         public PetHotbar PetHotbar { get; init; }
         public Keybinder Keybinder { get; init; }
 
+        public bool Ready;
+
         public Plugin(
             [RequiredVersion("1.0")] DalamudPluginInterface pluginInterface,
             [RequiredVersion("1.0")] CommandManager commandManager,
@@ -94,6 +96,7 @@ namespace HUD_Manager
             this.Keybinder = new Keybinder(this);
 
             if (!this.Config.FirstRun) {
+                this.Ready = true;
                 return;
             }
 
@@ -106,6 +109,8 @@ namespace HUD_Manager
             }
 
             this.Config.Save();
+
+            this.Ready = true;
         }
 
         public void Dispose()

--- a/HUDManager/Statuses.cs
+++ b/HUDManager/Statuses.cs
@@ -392,13 +392,13 @@ namespace HUD_Manager
                 case Status.ChatFocused:
                     return plugin.Statuses.IsChatFocused();
                 case Status.InputModeKbm:
-                    return !Util.GamepadModeActive();
+                    return !Util.GamepadModeActive(plugin);
                 case Status.InputModeGamepad:
-                    return Util.GamepadModeActive();
+                    return Util.GamepadModeActive(plugin);
                 case Status.Windowed:
-                    return !Util.FullScreen();
+                    return !Util.FullScreen(plugin);
                 case Status.FullScreen:
-                    return Util.FullScreen();
+                    return Util.FullScreen(plugin);
             }
 
             return false;

--- a/HUDManager/Structs/Layout.cs
+++ b/HUDManager/Structs/Layout.cs
@@ -6,8 +6,8 @@ namespace HUD_Manager.Structs
     [StructLayout(LayoutKind.Sequential)]
     public struct Layout
     {
-        // Size updated 6.11a
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 104)]
+        // Size updated 6.45
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 99)]
         public RawElement[] elements;
 
         public Dictionary<ElementKind, Element> ToDictionary()

--- a/HUDManager/Swapper.cs
+++ b/HUDManager/Swapper.cs
@@ -63,8 +63,10 @@ namespace HUD_Manager
 
             // Skipping due to HUD swaps in cutscenes causing main menu to become visible
             if (Plugin.Condition[ConditionFlag.OccupiedInCutSceneEvent]
-                || Plugin.Condition[ConditionFlag.WatchingCutscene78]
-                || Plugin.Condition[ConditionFlag.BoundByDuty95]) {
+                || Plugin.Condition[ConditionFlag.WatchingCutscene78] // Used in Dalamud's cutscene check
+                || Plugin.Condition[ConditionFlag.BoundByDuty95] // GATE: Air Force One
+                || Plugin.Condition[ConditionFlag.PlayingLordOfVerminion]
+                || Plugin.Condition[ConditionFlag.BetweenAreas51]) { // Loading Lord of Verminion
                 return;
             }
 

--- a/HUDManager/Swapper.cs
+++ b/HUDManager/Swapper.cs
@@ -37,13 +37,17 @@ namespace HUD_Manager
 
         public void OnTerritoryChange(object? sender, ushort tid)
         {
+            if (!this.Plugin.Ready) {
+                return;
+            }
+
             this.Plugin.Statuses.Update();
             this.Plugin.Statuses.SetHudLayout();
         }
 
         public void OnFrameworkUpdate(Framework framework)
         {
-            if (!this.Plugin.Config.SwapsEnabled || SwapsTemporarilyDisabled || !this.Plugin.Config.UnderstandsRisks) {
+            if (!this.Plugin.Ready || !this.Plugin.Config.SwapsEnabled || SwapsTemporarilyDisabled || !this.Plugin.Config.UnderstandsRisks) {
                 return;
             }
 

--- a/HUDManager/Ui/Editor/Previews.cs
+++ b/HUDManager/Ui/Editor/Previews.cs
@@ -2,6 +2,7 @@
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace HUD_Manager.Ui.Editor
 {
@@ -40,7 +41,9 @@ namespace HUD_Manager.Ui.Editor
                     continue;
                 }
 
-                var (pos, size) = ImGuiExt.ConvertGameToImGui(element);
+                var (outer, inner) = ImGuiExt.ConvertGameToImGui(element);
+                var (pos, size) = outer;
+
                 if (this.Update.Remove(element.Id)) {
                     ImGui.SetNextWindowPos(pos);
                 } else {
@@ -48,10 +51,11 @@ namespace HUD_Manager.Ui.Editor
                 }
 
                 ImGui.SetNextWindowSize(size);
-
+                ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0f, 0f, 0f, .5f));
                 if (!ImGui.Begin($"##uimanager-preview-{element.Id}", flags)) {
                     continue;
                 }
+                ImGui.PopStyleColor();
 
                 ImGui.TextUnformatted(element.Id.LocalisedName(this.Plugin.DataManager));
 
@@ -61,6 +65,12 @@ namespace HUD_Manager.Ui.Editor
                     element.X = newPos.X;
                     element.Y = newPos.Y;
                     update = true;
+                }
+
+                if (inner != null) {
+                    var drawList = ImGui.GetWindowDrawList();
+                    var (innerPos, innerSize) = inner;
+                    drawList.AddRectFilled(innerPos, innerPos + innerSize, 0x40FFFFFF);
                 }
 
                 ImGui.End();

--- a/HUDManager/Ui/Editor/Previews.cs
+++ b/HUDManager/Ui/Editor/Previews.cs
@@ -52,9 +52,13 @@ namespace HUD_Manager.Ui.Editor
 
                 ImGui.SetNextWindowSize(size);
                 ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0f, 0f, 0f, .5f));
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0);
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowMinSize, Vector2.Zero);
                 if (!ImGui.Begin($"##uimanager-preview-{element.Id}", flags)) {
                     continue;
                 }
+                ImGui.PopStyleVar(3);
                 ImGui.PopStyleColor();
 
                 ImGui.TextUnformatted(element.Id.LocalisedName(this.Plugin.DataManager));

--- a/HUDManager/Ui/ImGuiExt.cs
+++ b/HUDManager/Ui/ImGuiExt.cs
@@ -80,7 +80,22 @@ namespace HUD_Manager.Ui
             ImGui.Text(text);
         }
 
-        public static Tuple<Vector2, Vector2> ConvertGameToImGui(Element element)
+        public record OverlayPosition(Tuple<Vector2, Vector2> Outer, Tuple<Vector2, Vector2>? Inner);
+
+        public static OverlayPosition ConvertGameToImGui(Element element)
+        {
+            var inner = element.Id switch
+            {
+                ElementKind.TargetInfoProgressBar => ConvertGameToImGui(element, 246, 10, 204, 24, 1),
+                ElementKind.TargetInfoStatus => ConvertGameToImGui(element, 13, 45, 375, 82, 1),
+                ElementKind.TargetInfoHp => ConvertGameToImGui(element, 0, 0, -1, -1, 0.5f),
+                _ => null
+            };
+
+            return new OverlayPosition(ConvertGameToImGui(element, 0, 0, -1, -1, 1), inner);
+        }
+
+        private static Tuple<Vector2, Vector2> ConvertGameToImGui(Element element, int offsetX, int offsetY, int innerWidth, int innerHeight, float heightScale)
         {
             // get X & Y coords from the element, which are percentages (0 - 100)
             var percentagePos = new Vector2(element.X, element.Y);
@@ -123,8 +138,18 @@ namespace HUD_Manager.Ui
             pixelPos.Y -= subY;
 
             // round the coords
-            pixelPos.X = (float)Math.Round(pixelPos.X);
-            pixelPos.Y = (float)Math.Round(pixelPos.Y);
+            pixelPos.X = (float)Math.Round(pixelPos.X) + offsetX * element.Scale;
+            pixelPos.Y = (float)Math.Round(pixelPos.Y) + offsetY * element.Scale;
+
+            if (innerWidth > 0) {
+                size.X = innerWidth * element.Scale;
+            }
+
+            if (innerHeight > 0) {
+                size.Y = innerHeight * element.Scale;
+            }
+
+            size.Y *= heightScale;
 
             return Tuple.Create(pixelPos, size);
         }

--- a/HUDManager/Util.cs
+++ b/HUDManager/Util.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Data;
 using Dalamud.Logging;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.GeneratedSheets;
 using System.Collections.Generic;
 using System.Globalization;
@@ -33,23 +32,14 @@ namespace HUD_Manager
             }
         }
 
-        public static bool GamepadModeActive()
+        public static bool GamepadModeActive(Plugin plugin)
         {
-            unsafe {
-                var configModule = ConfigModule.Instance();
-                var option = configModule->GetIntValue((short)ConfigOption.PadMode);
-                return option > 0;
-            }
+            return plugin.GameConfig.UiConfig.TryGet("PadMode", out bool isPadMode) && isPadMode;
         }
 
-        public static bool FullScreen() // treats Borderless as Full Screen
+        public static bool FullScreen(Plugin plugin) // treats Borderless as Full Screen
         {
-            unsafe
-            {
-                var configModule = ConfigModule.Instance();
-                var option = configModule->GetIntValue((short)ConfigOption.ScreenMode);
-                return option > 0;
-            }
+            return plugin.GameConfig.System.TryGet("ScreenMode", out uint mode) && mode > 0;
         }
 
         public static bool IsCharacterConfigOpen()


### PR DESCRIPTION
[Ensure events can't run while plugin is partially loaded](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/70f5ec697ef49b5bfb85b4d8154396b122d8b858) - Makes it so that we don't react to events while the plugin is partially loaded. This rarely happened and wasn't a big problem, but could create errors in the plugin log.

[Prevent Hotbar1 cycling state from being reset on swap](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/ecda6b9aaf0bb257f55b1c9871e746cbf3a800e2) - Fixes the hotbar issue in #39 (minimap issue was addressed in the previous release).

[Use Dalamud GameConfig instead of ClientStructs ConfigModule](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/616158b678213366fdd3c2332b3378595f336101) - Use a more modern way way of fetching options via Dalamud instead of ClientStructs.

[Avoid issues which can happen when swapping during LoVM or its load screen](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/0a5ec7e794dcd121e1378d266f549620fbc77d28) - Addresses an issue which happened to me sometimes where the swaps happening during Lord of Verminion loading could sometimes mess up menu interactivity.

[Show inner position overlay for certain HUD elements](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/dfdf0258e6d54c30d3f5e92cd0060b1e6f1b6fd3) - Tries to address #50 by showing the inner element in a different color. This is perhaps not a perfect solution as it would be nice to measure from the inner frame, but that seemed quite difficult as it would involve complex pixel-space<->percentage-space translations in many places. Still, this helps visualize where the element will actually appear.

[Improve overlay accuracy](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/7411a7011586aad18e0de7be90a49ba7cd304d25) - Reduce the padding/borders which made element overlays substantially bigger than the actual element, and reduce the overlay window opacity to better be able to see layered elements.

[Update number of in-memory layout elements (fixes some marshalling isues)](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/b11440d893954ef0152d059aa251dfa38ba4d779) - Fix an issue discussed in Discord where elements were being imported from the wrong layout due to an outdated element count. Also fixes some position-overwriting issues which could happen with regular swaps.

[Bump version to 2.5.16.0](https://github.com/zacharied/FFXIV-Plugin-HudManager/commit/2d771b5e2fb71c283bb088e0e649decba65fc5c6) - Version bump.